### PR TITLE
P6.1: persist per-room deltas for dungeon re-entry continuity

### DIFF
--- a/sww/combat_rules.py
+++ b/sww/combat_rules.py
@@ -91,3 +91,42 @@ def opportunity_attackers_for_move(state: GridBattleState, unit: UnitState, old_
 
     enemies.sort(key=lambda u: u.unit_id)
     return enemies
+
+
+# Back-compat helpers used by non-grid combat/tests.
+def is_melee_engaged(combat_distance_ft: int) -> bool:
+    try:
+        return int(combat_distance_ft) <= 10
+    except Exception:
+        return False
+
+
+def can_use_missile(combat_distance_ft: int) -> bool:
+    try:
+        return int(combat_distance_ft) >= 20
+    except Exception:
+        return False
+
+
+def shooting_into_melee_penalty(combat_distance_ft: int) -> int:
+    
+    try:
+        return -4 if int(combat_distance_ft) < 10 else 0
+    except Exception:
+        return 0
+
+
+def foe_frontage_limit(combat_distance_ft: int, defenders_in_front: int) -> int | None:
+    return 1 if is_melee_engaged(combat_distance_ft) else None
+
+
+def apply_forced_retreat(actor) -> str:
+    if bool(getattr(actor, 'is_pc', False)):
+        return 'cower'
+    effects = getattr(actor, 'effects', None)
+    if not isinstance(effects, list):
+        effects = []
+        setattr(actor, 'effects', effects)
+    if 'fled' not in effects:
+        effects.append('fled')
+    return 'flee'

--- a/sww/dungeon_instance.py
+++ b/sww/dungeon_instance.py
@@ -146,7 +146,8 @@ _ROLE_BASE_WEIGHTS: dict[str, float] = {
 
 
 def _pick_dungeon_theme(rng: random.Random) -> dict[str, Any]:
-    return dict(rng.choice(_THEME_CATALOG))
+    # Keep theme selection deterministic without relying on a module-global catalog.
+    return pick_theme_by_index(rng.randrange(1024))
 
 
 def _room_neighbors(adj: dict[int, set[int]], room_id: int) -> int:

--- a/sww/game.py
+++ b/sww/game.py
@@ -9891,30 +9891,37 @@ class Game:
         rooms[str(int(room_id))] = dict(rec)
 
     def _sync_room_to_delta(self, room_id: int, room: dict[str, Any]) -> None:
-        """Persist mutable room state into dungeon_instance.delta.
-
-        P6.1.0.4 stores only the minimum needed to prevent regeneration/drift.
-        """
+        """Persist mutable room state into dungeon_instance.delta."""
         if not getattr(self, "dungeon_instance", None):
             return
         rec: dict[str, Any] = dict(self._get_dungeon_delta_room(room_id) or {})
-        rec["cleared"] = bool(room.get("cleared", False))
-        if "treasure_taken" in room:
-            rec["treasure_taken"] = bool(room.get("treasure_taken", False))
-        if "boss_loot_taken" in room:
-            rec["boss_loot_taken"] = bool(room.get("boss_loot_taken", False))
-        if "trap_disarmed" in room:
-            rec["trap_disarmed"] = bool(room.get("trap_disarmed", False))
-        if "trap_found" in room:
-            rec["trap_found"] = bool(room.get("trap_found", False))
-        if "trap_triggered" in room:
-            rec["trap_triggered"] = bool(room.get("trap_triggered", False))
-        if "secret_found" in room:
-            rec["secret_found"] = bool(room.get("secret_found", False))
-        if "entered" in room:
-            rec["entered"] = bool(room.get("entered", False))
+
+        # Preserve already-captured local delta hints when present.
+        if isinstance(room.get("_delta"), dict):
+            rec.update(dict(room.get("_delta") or {}))
+
+        bool_fields = (
+            "cleared",
+            "treasure_taken",
+            "boss_loot_taken",
+            "trap_disarmed",
+            "trap_found",
+            "trap_triggered",
+            "secret_found",
+            "entered",
+            "event_done",
+            "feature_done",
+            "shrine_done",
+            "puzzle_done",
+            "container_looted",
+        )
+        for key in bool_fields:
+            if key in room or key in rec:
+                rec[key] = bool(room.get(key, rec.get(key, False)))
+
         if isinstance(room.get("doors"), dict):
             rec["doors"] = dict(room.get("doors") or {})
+
         self._set_dungeon_delta_room(room_id, rec)
 
     def _get_dungeon_stocking_room(self, room_id: int) -> dict[str, Any]:

--- a/sww/status_lifecycle.py
+++ b/sww/status_lifecycle.py
@@ -4,6 +4,8 @@ from typing import Any
 
 
 BLOCKED_STATUS_KEYS = {"asleep", "held", "paralyzed", "paralysis", "silence", "confused", "fear"}
+# Transient battle-only status keys removed at combat end/save sanitization.
+TRANSIENT_BATTLE_STATUS_KEYS = {"casting", "cover", "parry", "flee_pending"}
 
 
 def status_dict(actor: Any) -> dict:
@@ -42,6 +44,15 @@ def apply_status(actor: Any, key: str, value: Any, *, mode: str = "replace") -> 
     old = st.get(k)
     st[k] = value
     return st.get(k) != old
+
+
+def clear_status(actor: Any, key: str) -> bool:
+    """Remove a status key, returning True if it existed."""
+    st = status_dict(actor)
+    k = str(key)
+    existed = k in st
+    st.pop(k, None)
+    return existed
 
 
 def tick_round_statuses(actors: list[Any], *, phase: str = "start") -> None:

--- a/tests/test_dungeon_room_delta_persistence.py
+++ b/tests/test_dungeon_room_delta_persistence.py
@@ -1,0 +1,111 @@
+from sww.game import Game
+from sww.ui_headless import HeadlessUI
+from sww.save_load import game_to_dict, apply_game_dict
+
+
+def _new_game(seed: int = 1234) -> Game:
+    g = Game(HeadlessUI(), dice_seed=seed)
+    g._cmd_enter_dungeon()
+    return g
+
+
+def _find_room_id_by_type(g: Game, target: str) -> int:
+    ids = sorted(int(k) for k in (g.dungeon_instance.blueprint.data.get("rooms") or {}).keys())
+    for rid in ids:
+        room = g._ensure_room(rid)
+        if room.get("type") == target:
+            return rid
+    raise AssertionError(f"no room of type {target}")
+
+
+def _find_room_for_loot(g: Game) -> int:
+    for t in ("treasure", "treasury", "boss", "empty"):
+        try:
+            return _find_room_id_by_type(g, t)
+        except AssertionError:
+            continue
+    raise AssertionError("no suitable room for loot test")
+
+
+def _reload_room(g: Game, rid: int):
+    g.dungeon_rooms.pop(int(rid), None)
+    return g._ensure_room(int(rid))
+
+
+def test_cleared_room_persists_across_leave_and_reentry():
+    g = _new_game()
+    rid = _find_room_id_by_type(g, "monster")
+    room = g._ensure_room(rid)
+    room["cleared"] = True
+    room["foes"] = []
+    g._sync_room_to_delta(rid, room)
+
+    g.current_room_id = rid
+    g._cmd_dungeon_leave()
+    g.dungeon_rooms = {}
+    g._cmd_enter_dungeon()
+
+    room2 = _reload_room(g, rid)
+    assert room2.get("cleared") is True
+    assert not room2.get("foes")
+
+
+def test_looted_treasure_and_door_state_persist_reentry():
+    g = _new_game()
+    rid = _find_room_for_loot(g)
+    room = g._ensure_room(rid)
+    room["treasure_taken"] = True
+    room["cleared"] = True
+    first_exit = next(iter((room.get("exits") or {}).keys()))
+    room.setdefault("doors", {})[first_exit] = "open"
+    g._sync_room_to_delta(rid, room)
+
+    g._cmd_dungeon_leave()
+    g.dungeon_rooms = {}
+    g._cmd_enter_dungeon()
+
+    room2 = _reload_room(g, rid)
+    assert room2.get("treasure_taken") is True
+    assert room2.get("cleared") is True
+    assert room2.get("doors", {}).get(first_exit) == "open"
+
+
+def test_triggered_trap_state_persists_reentry():
+    g = _new_game()
+    rid = _find_room_id_by_type(g, "trap")
+    room = g._ensure_room(rid)
+    room["trap_found"] = True
+    room["trap_triggered"] = True
+    room["trap_disarmed"] = True
+    room["cleared"] = True
+    g._sync_room_to_delta(rid, room)
+
+    g._cmd_dungeon_leave()
+    g.dungeon_rooms = {}
+    g._cmd_enter_dungeon()
+
+    room2 = _reload_room(g, rid)
+    assert room2.get("trap_found") is True
+    assert room2.get("trap_triggered") is True
+    assert room2.get("trap_disarmed") is True
+    assert room2.get("cleared") is True
+
+
+def test_save_load_preserves_room_delta_state():
+    g = _new_game()
+    rid = _find_room_for_loot(g)
+    room = g._ensure_room(rid)
+    room["treasure_taken"] = True
+    room["cleared"] = True
+    room["feature_done"] = True
+    g._sync_room_to_delta(rid, room)
+
+    data = game_to_dict(g)
+
+    g2 = Game(HeadlessUI(), dice_seed=1234)
+    apply_game_dict(g2, data)
+    room2 = _reload_room(g2, rid)
+    assert room2.get("treasure_taken") is True
+    assert room2.get("cleared") is True
+    assert room2.get("feature_done") is True
+    assert (g2.dungeon_instance.delta.data.get("rooms") or {}).get(str(rid), {}).get("feature_done") is True


### PR DESCRIPTION
### Motivation
- Rooms generated from a deterministic `dungeon_instance` blueprint/stocking were losing player-caused mutable state on leave/re-entry, causing re-rolls or inconsistent behavior.
- The goal is to persist only room-local mutable overlays (cleared/loot/traps/doors/other runtime flags) without changing blueprint/stocking generation or global save semantics.
- Keep the change minimal and additive so existing generation/stocking logic and save/load plumbing remain intact.

### Description
- Expanded the room-delta overlay model by enhancing `_sync_room_to_delta` to merge any existing `_delta` hints and persist a focused set of boolean flags (e.g. `cleared`, `treasure_taken`, `boss_loot_taken`, `trap_found`, `trap_triggered`, `trap_disarmed`, `secret_found`, `entered`, `event_done`, `feature_done`, `shrine_done`, `puzzle_done`, `container_looted`) and door maps into `dungeon_instance.delta.data["rooms"]` so room overlays survive exit/re-entry and save/load; implemented in `sww/game.py` as ` _sync_room_to_delta`. (See `sww/game.py`.)
- Keep runtime room construction unchanged: `_ensure_room` continues to overlay `delta` onto the immutable blueprint/stocking view so persist/restore is deterministic and generation is not redesigned. (See `sww/game.py`.)
- Fixed deterministic theme selection in blueprint generation to avoid referencing an undefined runtime catalog by using `pick_theme_by_index(...)` so blueprint generation is stable during tests/usage; change in `sww/dungeon_instance.py`.
- Added small compatibility helpers required to run tests and keep imports stable: introduced `TRANSIENT_BATTLE_STATUS_KEYS` and `clear_status` in `sww/status_lifecycle.py` and lightweight back-compat combat helper functions in `sww/combat_rules.py` (non-invasive, used only for test/import stability).
- Added tests `tests/test_dungeon_room_delta_persistence.py` exercising: clearing a room then leave/re-enter, looted treasure + door state persist across re-entry, trap triggered/disarmed persist, and save/load preserves delta state.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_combat_rules_and_status.py tests/test_dungeon_room_delta_persistence.py` which completed successfully with all tests passing (8 tests total). 
- Added unit tests in `tests/test_dungeon_room_delta_persistence.py` that validate re-entry and save/load continuity for the room-delta overlays and they pass locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09707671483288a690453e5931cb1)