### PR TITLE
Minimal P6.2 travel-state skeleton: deterministic town↔dungeon travel

### DIFF
--- a/sww/game.py
+++ b/sww/game.py
@@ -20,6 +20,7 @@ from .equipment import EquipmentDB
 from .ports import UIProtocol
 from .save_load import save_game, load_game, read_save_metadata
 from .wilderness import ensure_hex, neighbors, hex_distance, force_poi
+from .travel_state import TravelState, TOWN_HEX, DUNGEON_ENTRANCE_HEX
 from .factions import generate_static_core_factions, assign_territories, generate_static_conflict_clocks, clamp_rep
 from .contracts import generate_contracts, Contract
 from .events import EventLog
@@ -222,6 +223,7 @@ class Game:
         # world hexes stored as dicts keyed by "q,r" for easy JSON save.
         self.world_hexes: dict[str, dict[str, Any]] = {}
         self.party_hex = (0, 0)  # axial (q,r)
+        self.travel_state = TravelState(location="town")
         # Dedicated RNG for wilderness generation and rumor POI seeding.
         # Deterministic-ish replay log (non-persistent)
         self.replay = ReplayLog(dice_seed=self.dice_seed, wilderness_seed=self.wilderness_seed)
@@ -1966,7 +1968,9 @@ class Game:
 
 
         self.emit("traveled", mode="direction", direction=direction, src=src, dest=dest, travel_mode=str(getattr(self,'wilderness_travel_mode','normal')))
-
+        self.travel_state.location = "wilderness"
+        self.travel_state.travel_turns = int(getattr(self.travel_state, "travel_turns", 0)) + 1
+        self.travel_state.route_progress = int(getattr(self.travel_state, "route_progress", 0)) + 1
 
         return CommandResult(status="ok")
 
@@ -2010,7 +2014,9 @@ class Game:
 
 
         self.emit("traveled", mode="to_hex", src=src, dest=dest, travel_mode=str(getattr(self,'wilderness_travel_mode','normal')))
-
+        self.travel_state.location = "wilderness"
+        self.travel_state.travel_turns = int(getattr(self.travel_state, "travel_turns", 0)) + 1
+        self.travel_state.route_progress = int(getattr(self.travel_state, "route_progress", 0)) + 1
 
         return CommandResult(status="ok")
 
@@ -2087,7 +2093,9 @@ class Game:
 
 
         self.emit("traveled", mode="toward_town", src=src, dest=tuple(self.party_hex), travel_mode=str(getattr(self,'wilderness_travel_mode','normal')))
-
+        self.travel_state.location = "wilderness" if tuple(self.party_hex) != TOWN_HEX else "town"
+        self.travel_state.travel_turns = int(getattr(self.travel_state, "travel_turns", 0)) + 1
+        self.travel_state.route_progress = int(getattr(self.travel_state, "route_progress", 0)) + 1
 
         if self.party_hex == (0, 0):
 
@@ -2293,6 +2301,9 @@ class Game:
             distance=int(plan.get("distance", 0) or 0),
             modifiers=[{"reason": str(name), "delta": int(delta)} for (name, delta) in list(plan.get("modifiers", []))],
         )
+        self.travel_state.location = "town"
+        self.travel_state.travel_turns = int(getattr(self.travel_state, "travel_turns", 0)) + int(max(1, day_cost))
+        self.travel_state.route_progress = 0
         day_txt = f"{day_cost} day" + ("s" if day_cost != 1 else "")
         return CommandResult(status="ok", messages=(f"You return to Town. ({day_txt})",))
 
@@ -2310,6 +2321,20 @@ class Game:
     # -----------------
 
     def _cmd_enter_dungeon(self) -> CommandResult:
+        # Minimal deterministic overworld leg: town <-> canonical dungeon entrance.
+        if tuple(getattr(self, "party_hex", TOWN_HEX)) == TOWN_HEX:
+            self.party_hex = tuple(DUNGEON_ENTRANCE_HEX)
+            self.travel_state.location = "wilderness"
+            self.travel_state.travel_turns = int(getattr(self.travel_state, "travel_turns", 0)) + 1
+            self.travel_state.route_progress = int(getattr(self.travel_state, "route_progress", 0)) + 1
+
+        hx = self._ensure_current_hex()
+        poi = hx.get("poi") if isinstance(hx, dict) else None
+        at_entrance = tuple(getattr(self, "party_hex", TOWN_HEX)) == tuple(DUNGEON_ENTRANCE_HEX)
+        poi_entrance = isinstance(poi, dict) and str(poi.get("type") or "") == "dungeon_entrance"
+        if not (at_entrance or poi_entrance):
+            return CommandResult(status="error", messages=("You must be at a dungeon entrance to enter.",))
+
         self.ui.title("Dungeon Entrance")
         self.expeditions += 1
 
@@ -2354,6 +2379,7 @@ class Game:
             # Passive checks on initial room entry do not cost time.
             self._passive_room_entry_checks(r0)
 
+        self.travel_state.location = "dungeon"
         self.emit("dungeon_entered", room_id=int(self.current_room_id), expeditions=int(self.expeditions))
         return CommandResult(status="ok")
 
@@ -2918,6 +2944,8 @@ class Game:
         return CommandResult(status="ok")
 
     def _cmd_dungeon_leave(self) -> CommandResult:
+        self.party_hex = tuple(DUNGEON_ENTRANCE_HEX)
+        self.travel_state.location = "wilderness"
         self.emit("dungeon_left", room_id=int(self.current_room_id))
         return CommandResult(status="ok", messages=("leave",))
 

--- a/sww/save_load.py
+++ b/sww/save_load.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from .models import Actor, Party, Stats
+from .travel_state import TravelState
 
 # Increment whenever the on-disk schema changes.
 # We write both "save_version" and the legacy "version" key for compatibility.
@@ -194,6 +195,12 @@ def validate_and_guard_save_data(data: Any, strict: bool) -> Dict[str, Any]:
         if strict:
             _schema_fail("wilderness.world_hexes", f"expected object, got {_type_name(wild.get('world_hexes'))}")
         wild["world_hexes"] = {}
+
+    ts = wild.get("travel_state")
+    if ts is not None and not isinstance(ts, dict):
+        if strict:
+            _schema_fail("wilderness.travel_state", f"expected object, got {_type_name(ts)}")
+        wild["travel_state"] = {}
 
     # Dungeon essentials
     dung = data["dungeon"]
@@ -495,6 +502,7 @@ def game_to_dict(game: Any) -> Dict[str, Any]:
             "world_hexes": getattr(game, "world_hexes", {}) or {},
             "travel_mode": str(getattr(game, "wilderness_travel_mode", "normal") or "normal"),
             "forward_anchor": getattr(game, "forward_anchor", None),
+            "travel_state": (getattr(game, "travel_state", TravelState()).to_dict() if hasattr(getattr(game, "travel_state", None), "to_dict") else TravelState().to_dict()),
         },
         "journal": {
             "discoveries": list(getattr(game, "discovery_log", []) or []),
@@ -1162,6 +1170,7 @@ def apply_game_dict(game: Any, data: Dict[str, Any]) -> None:
     setattr(game, "world_hexes", wild.get("world_hexes", {}) or {})
     fa = wild.get("forward_anchor", None)
     setattr(game, "forward_anchor", fa if isinstance(fa, dict) else None)
+    setattr(game, "travel_state", TravelState.from_dict(wild.get("travel_state", {})))
 
     j = data.get("journal", {}) or {}
     setattr(game, "discovery_log", list(j.get("discoveries", []) or []))

--- a/sww/travel_state.py
+++ b/sww/travel_state.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+TOWN_HEX = (0, 0)
+DUNGEON_ENTRANCE_HEX = (0, 1)
+
+
+@dataclass
+class TravelState:
+    """Minimal P6.2 overworld travel ownership model.
+
+    Keeps state intentionally small so it is stable for save/load and easy to
+    evolve with future wilderness content.
+    """
+
+    location: str = "town"  # town | wilderness | dungeon
+    travel_turns: int = 0
+    route_progress: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "location": str(self.location or "town"),
+            "travel_turns": int(self.travel_turns or 0),
+            "route_progress": int(self.route_progress or 0),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "TravelState":
+        if not isinstance(data, dict):
+            return cls()
+        location = str(data.get("location") or "town").strip().lower()
+        if location not in ("town", "wilderness", "dungeon"):
+            location = "town"
+        try:
+            travel_turns = int(data.get("travel_turns", 0) or 0)
+        except Exception:
+            travel_turns = 0
+        try:
+            route_progress = int(data.get("route_progress", 0) or 0)
+        except Exception:
+            route_progress = 0
+        return cls(location=location, travel_turns=max(0, travel_turns), route_progress=max(0, route_progress))
+

--- a/tests/test_travel_state_skeleton.py
+++ b/tests/test_travel_state_skeleton.py
@@ -1,0 +1,76 @@
+from sww.game import Game
+from sww.ui_headless import HeadlessUI
+from sww.save_load import game_to_dict, apply_game_dict
+from sww.travel_state import DUNGEON_ENTRANCE_HEX, TOWN_HEX
+
+
+def _new_game(seed: int = 7777) -> Game:
+    return Game(HeadlessUI(), dice_seed=seed, wilderness_seed=seed + 1)
+
+
+def test_travel_state_persists_across_save_load():
+    g = _new_game()
+    g._cmd_enter_dungeon()
+    g._cmd_dungeon_leave()
+    g._cmd_step_toward_town()
+
+    data = game_to_dict(g)
+    g2 = _new_game()
+    apply_game_dict(g2, data)
+
+    assert g2.travel_state.to_dict() == g.travel_state.to_dict()
+    assert tuple(g2.party_hex) == tuple(g.party_hex)
+
+
+def test_travel_turns_advance_deterministically():
+    g1 = _new_game(seed=8100)
+    g2 = _new_game(seed=8100)
+
+    assert g1._cmd_enter_dungeon().ok
+    assert g2._cmd_enter_dungeon().ok
+    assert g1._cmd_dungeon_leave().ok
+    assert g2._cmd_dungeon_leave().ok
+    assert g1._cmd_step_toward_town().ok
+    assert g2._cmd_step_toward_town().ok
+
+    assert g1.travel_state.travel_turns == g2.travel_state.travel_turns
+    assert g1.travel_state.route_progress == g2.travel_state.route_progress
+    assert g1.travel_state.location == g2.travel_state.location
+
+
+def test_town_to_dungeon_entrance_and_back_is_stable():
+    g = _new_game()
+
+    assert tuple(g.party_hex) == tuple(TOWN_HEX)
+    assert g._cmd_enter_dungeon().ok
+    assert g.travel_state.location == "dungeon"
+
+    assert g._cmd_dungeon_leave().ok
+    assert tuple(g.party_hex) == tuple(DUNGEON_ENTRANCE_HEX)
+    assert g.travel_state.location == "wilderness"
+
+    assert g._cmd_step_toward_town().ok
+    assert tuple(g.party_hex) == tuple(TOWN_HEX)
+    assert g.travel_state.location == "town"
+
+
+def test_repeated_transitions_keep_town_and_dungeon_state_stable():
+    g = _new_game(seed=9200)
+    g._wilderness_encounter_check = lambda hx, encounter_mod=0: None
+
+    assert g._cmd_enter_dungeon().ok
+    baseline_instance_id = (g.dungeon_instance.dungeon_id, int(g.dungeon_instance.seed))
+    baseline_room = int(g.current_room_id)
+    baseline_expeditions = int(g.expeditions)
+
+    for _ in range(3):
+        assert g._cmd_dungeon_leave().ok
+        assert tuple(g.party_hex) == tuple(DUNGEON_ENTRANCE_HEX)
+        assert g._cmd_step_toward_town().ok
+        assert tuple(g.party_hex) == tuple(TOWN_HEX)
+        assert g._cmd_enter_dungeon().ok
+
+    assert (g.dungeon_instance.dungeon_id, int(g.dungeon_instance.seed)) == baseline_instance_id
+    assert int(g.current_room_id) >= 1
+    assert int(g.expeditions) == baseline_expeditions + 3
+    assert int(g.current_room_id) == baseline_room


### PR DESCRIPTION
### Motivation
- Introduce a minimal, deterministic overworld/travel ownership layer so town and dungeon play can be connected safely without implementing the full wilderness content system.
- Keep the model small and stable for save/load and provide clean hooks for future POIs, encounters, and route logic.

### Description
- Added a compact `TravelState` model (`location`, `travel_turns`, `route_progress`) and canonical hex constants `TOWN_HEX` and `DUNGEON_ENTRANCE_HEX` in `sww/travel_state.py` to own basic travel state and conversion helpers.
- Wired `Game` to own `travel_state` and update it on core wilderness transitions (`_cmd_travel_direction`, `_cmd_travel_to_hex`, `_cmd_step_toward_town`, and safe `_cmd_return_to_town`) so travel time and route progress are tracked deterministically.
- Implemented a minimal deterministic town→dungeon bridge in `_cmd_enter_dungeon` that moves the party from town to a canonical dungeon-entrance hex (or requires a `dungeon_entrance` POI) before instancing the dungeon, and restored wilderness placement on `_cmd_dungeon_leave`.
- Added save/load schema guards and serialization/re-hydration for `wilderness.travel_state` in `sww/save_load.py` and added focused tests in `tests/test_travel_state_skeleton.py` to validate persistence and stable transitions.
- Files changed: `sww/travel_state.py` (new), `sww/game.py` (modified), `sww/save_load.py` (modified), `tests/test_travel_state_skeleton.py` (new).

### Testing
- Ran the focused test suite with `PYTHONPATH=. pytest -q tests/test_travel_state_skeleton.py tests/test_dungeon_room_delta_persistence.py` and confirmed all tests passed.
- Result: `8 passed` (new travel-state tests plus existing dungeon room delta persistence tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a13c0f308328876b760cfb0627da)