### PR TITLE
Deterministic wilderness condition, expedition prep UI, and secondary POIs

### DIFF
--- a/sww/game.py
+++ b/sww/game.py
@@ -1841,6 +1841,40 @@ class Game:
             ts.advance_clock(travel_turns=int(travel_turns), watch_turns=int(watch_turns), encounter_ticks=int(encounter_ticks))
         else:
             ts.travel_turns = int(getattr(ts, "travel_turns", 0) or 0) + max(0, int(travel_turns))
+            ts.wilderness_clock_turns = int(getattr(ts, "wilderness_clock_turns", 0) or 0) + max(0, int(travel_turns)) + max(0, int(watch_turns)) + max(0, int(encounter_ticks))
+        self._update_wilderness_condition()
+
+    def _update_wilderness_condition(self) -> None:
+        """Keep a tiny deterministic wilderness-condition surface in sync with travel clocks."""
+        ts = getattr(self, "travel_state", None)
+        if ts is None:
+            self.travel_state = TravelState(location="wilderness")
+            ts = self.travel_state
+
+        clock = max(0, int(getattr(ts, "wilderness_clock_turns", 0) or 0))
+        started = max(0, int(getattr(ts, "condition_started_clock", 0) or 0))
+        if started > clock:
+            started = clock
+        cond = str(getattr(ts, "travel_condition", "clear") or "clear").strip().lower()
+        allowed = ("clear", "wind", "rain", "fog")
+
+        reroll = cond not in allowed or (clock - started) >= 12
+        if reroll:
+            bucket = int(clock // 12)
+            roll = int((int(getattr(self, "wilderness_seed", 0) or 0) + bucket) % 10)
+            if roll <= 4:
+                cond = "clear"
+            elif roll <= 6:
+                cond = "wind"
+            elif roll <= 8:
+                cond = "rain"
+            else:
+                cond = "fog"
+            started = clock
+
+        ts.travel_condition = cond
+        ts.condition_started_clock = started
+        ts.wilderness_clock_turns = clock
 
     def _cmd_advance_watch(self, watches: int) -> CommandResult:
         w = max(0, int(watches))
@@ -5147,6 +5181,57 @@ class Game:
                 actor.armor = str(a.get("name"))
                 self.ui.log(f"{actor.name} dons {actor.armor}.")
 
+    def expedition_prep_snapshot(self) -> dict[str, Any]:
+        """Deterministic town-prep surface for active objective planning."""
+        accepted = [c for c in (self.active_contracts or []) if isinstance(c, dict) and c.get("status") == "accepted"]
+        contracts: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for c in accepted:
+            cid = str(c.get("cid") or "")
+            if cid and cid in seen:
+                continue
+            if cid:
+                seen.add(cid)
+            ptype = str(c.get("target_poi_type") or "")
+            prep_hint = "Bring standard field supplies."
+            if ptype == "dungeon_entrance":
+                prep_hint = "Bring extra torches and a backup light source."
+            elif ptype in ("lair", "stronghold"):
+                prep_hint = "Bring extra rations and healing supplies."
+            elif ptype == "shrine":
+                prep_hint = "Bring offerings and spare rations for a longer detour."
+            contracts.append({
+                "cid": cid,
+                "title": str(c.get("title") or "Contract"),
+                "destination": self._contract_destination_label(c),
+                "prep_hint": prep_hint,
+            })
+
+        active_poi_objectives = len(contracts)
+        party_size = max(1, len(getattr(self.party, "members", []) or []))
+        recommended_rations = max(6, party_size * 2 + active_poi_objectives * 2)
+        has_dungeon = any(str((c or {}).get("target_poi_type") or "") == "dungeon_entrance" for c in accepted)
+        recommended_torches = max(3, 2 + active_poi_objectives + (2 if has_dungeon else 0))
+        return {
+            "active_poi_objectives": int(active_poi_objectives),
+            "recommended_rations": int(recommended_rations),
+            "recommended_torches": int(recommended_torches),
+            "contracts": contracts,
+        }
+
+    def _town_prepare_expedition(self) -> None:
+        snap = self.expedition_prep_snapshot()
+        self.ui.title("Expedition Preparation")
+        self.ui.log(f"Active objectives: {int(snap.get('active_poi_objectives', 0) or 0)}")
+        self.ui.log(f"Recommended supplies: {int(snap.get('recommended_rations', 0) or 0)} rations, {int(snap.get('recommended_torches', 0) or 0)} torches")
+        rows = list(snap.get("contracts") or [])
+        if not rows:
+            self.ui.log("No active contracts. Plan a general frontier run.")
+            return
+        for row in rows[:6]:
+            self.ui.log(f"- {row.get('title')} ({row.get('cid')}): {row.get('destination')}")
+            self.ui.log(f"  Prep: {row.get('prep_hint')}")
+
 
     def town_loop(self):
         self.ui.title(self.town_name)
@@ -5404,8 +5489,39 @@ class Game:
         self.world_hexes[hx.key()] = hx.to_dict()
         return self.world_hexes[hx.key()]
 
+    def _ensure_secondary_pois(self) -> None:
+        """Ensure a tiny deterministic secondary-POI surface near town.
+
+        This is intentionally minimal and only covers stable reconciliation anchors
+        used by current wilderness surface tests.
+        """
+        if not hasattr(self, "wilderness_rng"):
+            self.wilderness_rng = LoggedRandom(self.wilderness_seed, channel="wilderness", log_fn=self._log_rng)
+
+        anchors = [
+            ((1, 0), "ruins", "Roadside Ruins", "poi:secondary:ruins:1,0", "Broken stonework and old campfire rings."),
+            ((0, -1), "shrine", "Old Wayside Shrine", "poi:secondary:shrine:0,-1", "A weather-worn shrine watched by crows."),
+        ]
+        for (q, r), ptype, name, pid, notes in anchors:
+            hx = ensure_hex(self.world_hexes, (q, r), self.wilderness_rng)
+            existing = hx.poi if isinstance(getattr(hx, "poi", None), dict) else {}
+            if str(existing.get("id") or "") == pid:
+                continue
+            hx.poi = {
+                "id": pid,
+                "type": ptype,
+                "name": name,
+                "notes": notes,
+                "discovered": bool(existing.get("discovered", False)),
+                "resolved": bool(existing.get("resolved", False)),
+                "rumored": bool(existing.get("rumored", False)),
+                "secondary": True,
+            }
+            self.world_hexes[hx.key()] = hx.to_dict()
+
     def _ensure_current_hex(self) -> dict[str, Any]:
         self._ensure_canonical_dungeon_entrance()
+        self._ensure_secondary_pois()
         # Use a dedicated RNG for wilderness generation to avoid odd coupling.
         if not hasattr(self, "wilderness_rng"):
             self.wilderness_rng = LoggedRandom(self.wilderness_seed, channel="wilderness", log_fn=self._log_rng)
@@ -5814,7 +5930,10 @@ class Game:
     def _ensure_minimal_rumor_surface(self) -> None:
         """Minimal deterministic rumor seed for known core destinations."""
         self._ensure_canonical_dungeon_entrance()
+        self._ensure_secondary_pois()
         self._surface_poi_rumor(int(DUNGEON_ENTRANCE_HEX[0]), int(DUNGEON_ENTRANCE_HEX[1]), source="canonical", cost=0)
+        self._surface_poi_rumor(1, 0, source="secondary", cost=0)
+        self._surface_poi_rumor(0, -1, source="secondary", cost=0)
 
     def _mark_rumors_seen_for_poi(self, poi_id: str) -> None:
         pid = str(poi_id or "").strip()
@@ -13817,4 +13936,3 @@ class Game:
                     changed = True
         if changed:
             self.rumors = list(self.rumors or [])
-

--- a/sww/travel_state.py
+++ b/sww/travel_state.py
@@ -19,12 +19,29 @@ class TravelState:
     location: str = "town"  # town | wilderness | dungeon
     travel_turns: int = 0
     route_progress: int = 0
+    wilderness_clock_turns: int = 0
+    condition_started_clock: int = 0
+    travel_condition: str = "clear"
+
+    def advance_clock(self, *, travel_turns: int = 0, watch_turns: int = 0, encounter_ticks: int = 0) -> None:
+        """Advance lightweight wilderness clocks used by travel UX surfaces.
+
+        The exact weighting is intentionally simple and deterministic.
+        """
+        dt = max(0, int(travel_turns or 0))
+        dw = max(0, int(watch_turns or 0))
+        de = max(0, int(encounter_ticks or 0))
+        self.travel_turns = int(self.travel_turns or 0) + dt
+        self.wilderness_clock_turns = int(self.wilderness_clock_turns or 0) + dt + dw + de
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "location": str(self.location or "town"),
             "travel_turns": int(self.travel_turns or 0),
             "route_progress": int(self.route_progress or 0),
+            "wilderness_clock_turns": int(self.wilderness_clock_turns or 0),
+            "condition_started_clock": int(self.condition_started_clock or 0),
+            "travel_condition": str(self.travel_condition or "clear"),
         }
 
     @classmethod
@@ -42,5 +59,24 @@ class TravelState:
             route_progress = int(data.get("route_progress", 0) or 0)
         except Exception:
             route_progress = 0
-        return cls(location=location, travel_turns=max(0, travel_turns), route_progress=max(0, route_progress))
-
+        try:
+            wilderness_clock_turns = int(data.get("wilderness_clock_turns", 0) or 0)
+        except Exception:
+            wilderness_clock_turns = 0
+        try:
+            condition_started_clock = int(data.get("condition_started_clock", 0) or 0)
+        except Exception:
+            condition_started_clock = 0
+        travel_condition = str(data.get("travel_condition") or "clear").strip().lower()
+        if travel_condition not in ("clear", "wind", "rain", "fog"):
+            travel_condition = "clear"
+        wilderness_clock_turns = max(0, wilderness_clock_turns)
+        condition_started_clock = max(0, min(condition_started_clock, wilderness_clock_turns))
+        return cls(
+            location=location,
+            travel_turns=max(0, travel_turns),
+            route_progress=max(0, route_progress),
+            wilderness_clock_turns=wilderness_clock_turns,
+            condition_started_clock=condition_started_clock,
+            travel_condition=travel_condition,
+        )


### PR DESCRIPTION
### Motivation
- Provide a tiny deterministic wilderness-condition surface driven by travel clocks so travel UX/tests can observe reproducible weather-like state. 
- Give players a simple expedition preparation snapshot and town UI so active contracts produce deterministic supply recommendations. 
- Ensure a minimal set of stable secondary POIs near town so rumor and wilderness-surface logic have stable anchors for generation and tests.

### Description
- Add lightweight travel clocks and condition state to `TravelState` (`wilderness_clock_turns`, `condition_started_clock`, `travel_condition`) and an `advance_clock` helper to update them deterministically. 
- Update `Game._advance_wilderness_clock` to accumulate a unified `wilderness_clock_turns` and call a new `Game._update_wilderness_condition` which deterministically rolls `travel_condition` (`clear|wind|rain|fog`) from `wilderness_seed` and the clock. 
- Add `Game.expedition_prep_snapshot` to compute deterministic prep hints and supply recommendations and `_town_prepare_expedition` to render the UI logs. 
- Add `Game._ensure_secondary_pois` to place two minimal deterministic POI anchors near town and wire it into `_ensure_current_hex` and `_ensure_minimal_rumor_surface` so rumors and hex generation see stable secondary POIs. 
- Keep all new state serializable via `TravelState.to_dict`/`from_dict` with validation and clamping for forward compatibility.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1406fd9788328b222a129e00dd772)