### PR TITLE
Town progression: add services, prep shortcuts, and clearer progression feedback

### DIFF
--- a/sww/game.py
+++ b/sww/game.py
@@ -5329,6 +5329,30 @@ class Game:
         self.ui.log("Purchased basic delve kit: +6 rations, +4 torches, +20 arrows, +20 bolts.")
         return True
 
+    def _town_minor_healing_rite(self, *, cost: int = 8, pool: int = 8, label: str = "Temple rites mend wounds") -> bool:
+        injured = [m for m in self.party.living() if int(getattr(m, "hp", 0) or 0) < int(getattr(m, "hp_max", 0) or 0)]
+        if not injured:
+            self.ui.log("No one needs healing right now.")
+            return False
+        if self.gold < int(cost):
+            self.ui.log("Not enough gold.")
+            return False
+        self.gold -= int(cost)
+        rem = int(pool)
+        healed = 0
+        for m in sorted(injured, key=lambda a: (int(a.hp) / max(1, int(a.hp_max)), int(a.hp))):
+            if rem <= 0:
+                break
+            need = max(0, int(m.hp_max) - int(m.hp))
+            if need <= 0:
+                continue
+            amt = min(need, rem)
+            m.hp = int(m.hp) + int(amt)
+            rem -= int(amt)
+            healed += int(amt)
+        self.ui.log(f"{label}. (Healed {healed} HP total.)")
+        return True
+
     def _town_temple_healing(self) -> None:
         injured = [m for m in self.party.living() if int(getattr(m, "hp", 0) or 0) < int(getattr(m, "hp_max", 0) or 0)]
         if not injured:
@@ -5346,20 +5370,7 @@ class Game:
             if self.gold < 8:
                 self.ui.log("Not enough gold.")
                 return
-            self.gold -= 8
-            pool = 8
-            healed = 0
-            for m in sorted(injured, key=lambda a: (int(a.hp) / max(1, int(a.hp_max)), int(a.hp))):
-                if pool <= 0:
-                    break
-                need = max(0, int(m.hp_max) - int(m.hp))
-                if need <= 0:
-                    continue
-                amt = min(need, pool)
-                m.hp = int(m.hp) + int(amt)
-                pool -= int(amt)
-                healed += int(amt)
-            self.ui.log(f"Temple rites mend wounds. (Healed {healed} HP total.)")
+            self._town_minor_healing_rite(cost=8, pool=8, label="Temple rites mend wounds")
             return
         if self.gold < full_cost:
             self.ui.log("Not enough gold.")
@@ -5468,23 +5479,7 @@ class Game:
         if c == 0:
             self._town_buy_basic_resupply()
         elif c == 1:
-            if self.gold < 8:
-                self.ui.log("Not enough gold.")
-                return
-            self.gold -= 8
-            pool = 8
-            healed = 0
-            for m in sorted(self.party.living(), key=lambda a: (int(a.hp) / max(1, int(a.hp_max)), int(a.hp))):
-                if pool <= 0:
-                    break
-                need = max(0, int(m.hp_max) - int(m.hp))
-                if need <= 0:
-                    continue
-                amt = min(need, pool)
-                m.hp = int(m.hp) + int(amt)
-                pool -= int(amt)
-                healed += int(amt)
-            self.ui.log(f"Temple attendants patch up the party. (Healed {healed} HP total.)")
+            self._town_minor_healing_rite(cost=8, pool=8, label="Temple attendants patch up the party")
         elif c == 2:
             self._town_services_menu()
 

--- a/tests/test_town_progression_depth.py
+++ b/tests/test_town_progression_depth.py
@@ -86,3 +86,15 @@ def test_return_to_town_and_training_show_progression_feedback():
     assert any("to next:" in ln for ln in g.ui.lines)
     assert any("Training Hero for level" in ln for ln in g.ui.lines)
     assert any("Level-up summary:" in ln for ln in g.ui.lines)
+
+
+def test_prep_minor_healing_shortcut_does_not_charge_when_uninjured():
+    ui = _SeqUI([1])
+    g = Game(ui, dice_seed=20030, wilderness_seed=20031)
+    g.gold = 50
+    g.party.members = [_pc(hp=8, hp_max=8)]
+
+    g._town_prepare_expedition()
+
+    assert g.gold == 50
+    assert any("No one needs healing right now." in ln for ln in g.ui.lines)


### PR DESCRIPTION
### Motivation

- Make the Town phase a strategic reset layer by adding meaningful gold sinks, clearer progression feedback, and deliberate prep choices without touching combat or travel systems. 

### Description

- Added a new `Town Services` menu and service handlers: ` _town_services_menu`, `_town_temple_healing`, `_town_identify_items`, `_town_buy_basic_resupply`, and `_town_lodging_service` to provide modest, deterministic gold sinks for healing, identification, bundled resupply, and lodging.
- Extended expedition prep with `recommended_arrows`/`recommended_bolts` and a `warnings` list in `expedition_prep_snapshot`, and updated `_town_prepare_expedition` to display those warnings and provide prep shortcuts (one-click delve kit / minor temple healing / open Town Services).
- Improved progression clarity by adding a return-to-town recap in `_cmd_return_to_town` that logs per-PC XP-to-next and HP status, and enhanced `train_party` + `level_up_pc` to log the training fee and a concise level-up summary including HP/save changes and spell-slot differences.
- Kept all changes localized to `sww/game.py` and added a focused unit test file `tests/test_town_progression_depth.py` covering the new services, prep snapshot fields, and progression messaging.

### Testing

- Ran `PYTHONPATH=. pytest -q tests/test_town_expedition_prep.py -q` which passed.
- Ran `PYTHONPATH=. pytest -q tests/test_town_expedition_prep.py tests/test_town_progression_depth.py tests/test_contract_completion_feedback.py tests/test_contract_menu_flow_cleanup.py -q` which passed.
- Ran `PYTHONPATH=. pytest -q tests/test_town_progression_depth.py tests/test_town_expedition_prep.py -q` which passed.
- Performed a broader town/prep/wilderness sweep (`PYTHONPATH=. pytest -q tests/test_*town* tests/test_*prep* tests/test_*wilderness* -q`); this exposed two existing wilderness clock / scheduler failures unrelated to these town changes (failures observed in `tests/test_wilderness_clock_integration.py` and `tests/test_wilderness_encounter_scheduler.py`). Other requested wildcard targets (e.g. `test_*shop*`, `test_*economy*`, `test_*level*`, `test_*xp*`) do not exist in this repository so they were skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b163ad2e5c8328885bf128130d9551)