### PR TITLE
Stabilize wilderness clock and encounter scheduler on return-to-town

### DIFF
--- a/sww/game.py
+++ b/sww/game.py
@@ -1923,6 +1923,14 @@ class Game:
         ts.condition_started_clock = started
         ts.wilderness_clock_turns = clock
 
+    def _wilderness_encounter_due(self) -> bool:
+        ts = getattr(self, "travel_state", None)
+        if ts is None:
+            return False
+        ticks = int(getattr(ts, "encounter_clock_ticks", 0) or 0)
+        next_tick = int(getattr(ts, "encounter_next_check_tick", 1) or 1)
+        return ticks >= max(1, next_tick)
+
     def _cmd_advance_watch(self, watches: int) -> CommandResult:
         w = max(0, int(watches))
         if w <= 0:
@@ -2402,8 +2410,12 @@ class Game:
             distance=int(plan.get("distance", 0) or 0),
             modifiers=[{"reason": str(name), "delta": int(delta)} for (name, delta) in list(plan.get("modifiers", []))],
         )
+        self._advance_wilderness_clock(
+            travel_turns=int(max(1, day_cost)),
+            watch_turns=int(max(1, day_cost)) * int(self.WATCHES_PER_DAY),
+            encounter_ticks=1,
+        )
         self.travel_state.location = "town"
-        self.travel_state.travel_turns = int(getattr(self.travel_state, "travel_turns", 0)) + int(max(1, day_cost))
         self.travel_state.route_progress = 0
         self.ui.title("Return to Town")
         self.ui.log(f"Travel time: {day_cost} day(s).")

--- a/sww/travel_state.py
+++ b/sww/travel_state.py
@@ -20,6 +20,8 @@ class TravelState:
     travel_turns: int = 0
     route_progress: int = 0
     wilderness_clock_turns: int = 0
+    encounter_clock_ticks: int = 0
+    encounter_next_check_tick: int = 1
     condition_started_clock: int = 0
     travel_condition: str = "clear"
 
@@ -33,6 +35,11 @@ class TravelState:
         de = max(0, int(encounter_ticks or 0))
         self.travel_turns = int(self.travel_turns or 0) + dt
         self.wilderness_clock_turns = int(self.wilderness_clock_turns or 0) + dt + dw + de
+        self.encounter_clock_ticks = int(getattr(self, "encounter_clock_ticks", 0) or 0) + de
+        next_tick = int(getattr(self, "encounter_next_check_tick", 1) or 1)
+        if next_tick <= int(self.encounter_clock_ticks):
+            next_tick = int(self.encounter_clock_ticks) + 1
+        self.encounter_next_check_tick = max(1, next_tick)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -40,6 +47,8 @@ class TravelState:
             "travel_turns": int(self.travel_turns or 0),
             "route_progress": int(self.route_progress or 0),
             "wilderness_clock_turns": int(self.wilderness_clock_turns or 0),
+            "encounter_clock_ticks": int(getattr(self, "encounter_clock_ticks", 0) or 0),
+            "encounter_next_check_tick": int(getattr(self, "encounter_next_check_tick", 1) or 1),
             "condition_started_clock": int(self.condition_started_clock or 0),
             "travel_condition": str(self.travel_condition or "clear"),
         }
@@ -64,6 +73,14 @@ class TravelState:
         except Exception:
             wilderness_clock_turns = 0
         try:
+            encounter_clock_ticks = int(data.get("encounter_clock_ticks", 0) or 0)
+        except Exception:
+            encounter_clock_ticks = 0
+        try:
+            encounter_next_check_tick = int(data.get("encounter_next_check_tick", 1) or 1)
+        except Exception:
+            encounter_next_check_tick = 1
+        try:
             condition_started_clock = int(data.get("condition_started_clock", 0) or 0)
         except Exception:
             condition_started_clock = 0
@@ -71,12 +88,16 @@ class TravelState:
         if travel_condition not in ("clear", "wind", "rain", "fog"):
             travel_condition = "clear"
         wilderness_clock_turns = max(0, wilderness_clock_turns)
+        encounter_clock_ticks = max(0, encounter_clock_ticks)
+        encounter_next_check_tick = max(encounter_clock_ticks + 1, max(1, encounter_next_check_tick))
         condition_started_clock = max(0, min(condition_started_clock, wilderness_clock_turns))
         return cls(
             location=location,
             travel_turns=max(0, travel_turns),
             route_progress=max(0, route_progress),
             wilderness_clock_turns=wilderness_clock_turns,
+            encounter_clock_ticks=encounter_clock_ticks,
+            encounter_next_check_tick=encounter_next_check_tick,
             condition_started_clock=condition_started_clock,
             travel_condition=travel_condition,
         )


### PR DESCRIPTION
### Motivation
- Fix two regressions where return-to-town did not advance wilderness encounter/scheduler state coherently while keeping town progression and other systems untouched.
- Make the travel/return timing ownership explicit and deterministic so step-travel and safe-return produce repeatable scheduler behavior.

### Description
- Added scheduler counters to `TravelState`: `encounter_clock_ticks` and `encounter_next_check_tick`, persisted via `to_dict`/`from_dict` and bounded deterministically. (`sww/travel_state.py`)
- Extended `TravelState.advance_clock(...)` to advance `encounter_clock_ticks` and maintain `encounter_next_check_tick` so encounter scheduling is advanced by the same authoritative clock path used for travel. (`sww/travel_state.py`)
- Added `Game._wilderness_encounter_due()` to provide a clear query for whether an encounter check is due based on `TravelState` scheduler fields. (`sww/game.py`)
- Reworked `Game._cmd_return_to_town()` to route return timing through `_advance_wilderness_clock(...)` (travel turns, watches, and a single encounter tick) instead of mutating travel counters piecemeal, centralizing timing ownership. (`sww/game.py`)

### Testing
- Ran the focused failing tests and suites locally and they passed: `PYTHONPATH=. pytest -q tests/test_wilderness_clock_integration.py::test_return_to_town_and_step_travel_advance_clock_as_intended -q` (passed) and `PYTHONPATH=. pytest -q tests/test_wilderness_encounter_scheduler.py::test_return_to_town_interacts_with_scheduler_coherently -q` (passed).
- Ran broader related suites to catch regressions and they passed: `PYTHONPATH=. pytest -q tests/test_wilderness_clock_integration.py -q`, `PYTHONPATH=. pytest -q tests/test_wilderness_encounter_scheduler.py -q`, and `PYTHONPATH=. pytest -q tests/test_town_progression_depth.py -q` (all passed).
- Also executed a multi-file town regression smoke run `PYTHONPATH=. pytest -q tests/test_town_expedition_prep.py tests/test_town_progression_depth.py tests/test_contract_completion_feedback.py tests/test_contract_menu_flow_cleanup.py -q` and it passed to confirm no town progression regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b168f6b9448328933c5e5aae3ea419)