### PR TITLE
Record and project expedition events; persist encounter clock state

### DIFF
--- a/sww/events.py
+++ b/sww/events.py
@@ -177,6 +177,25 @@ def project_clues_from_events(event_history: Iterable[Dict[str, Any]] | None) ->
     return out
 
 
+
+
+def project_expeditions_from_events(event_history: Iterable[Dict[str, Any]] | None) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for ev in _iter_events_in_eid_order(event_history):
+        et = str((ev or {}).get("type") or "")
+        if et not in ("expedition.departed", "expedition.returned", "poi.explored", "dungeon.depth_reached", "contract.completed"):
+            continue
+        p = dict((ev or {}).get("payload") or {})
+        row = {
+            "day": _safe_int((ev or {}).get("day", p.get("day", 1)), 1),
+            "watch": _safe_int((ev or {}).get("watch", p.get("watch", 0)), 0),
+            "type": et,
+            "title": str((ev or {}).get("title") or ""),
+            "payload": p,
+        }
+        out.append(row)
+    return out
+
 def project_district_notes_from_events(event_history: Iterable[Dict[str, Any]] | None) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for ev in _iter_events_in_eid_order(event_history):

--- a/sww/game.py
+++ b/sww/game.py
@@ -29,6 +29,7 @@ from .events import (
     project_clues_from_events,
     project_discoveries_from_events,
     project_district_notes_from_events,
+    project_expeditions_from_events,
     project_rumors_from_events,
 )
 from .effects import EffectsManager, Hook
@@ -1923,6 +1924,14 @@ class Game:
         ts.condition_started_clock = started
         ts.wilderness_clock_turns = clock
 
+    def _wilderness_encounter_due(self) -> bool:
+        ts = getattr(self, "travel_state", None)
+        if ts is None:
+            return False
+        ticks = int(getattr(ts, "encounter_clock_ticks", 0) or 0)
+        next_tick = int(getattr(ts, "encounter_next_check_tick", 1) or 1)
+        return ticks >= max(1, next_tick)
+
     def _cmd_advance_watch(self, watches: int) -> CommandResult:
         w = max(0, int(watches))
         if w <= 0:
@@ -2402,9 +2411,20 @@ class Game:
             distance=int(plan.get("distance", 0) or 0),
             modifiers=[{"reason": str(name), "delta": int(delta)} for (name, delta) in list(plan.get("modifiers", []))],
         )
+        self._advance_wilderness_clock(
+            travel_turns=int(max(1, day_cost)),
+            watch_turns=int(max(1, day_cost)) * int(self.WATCHES_PER_DAY),
+            encounter_ticks=1,
+        )
         self.travel_state.location = "town"
-        self.travel_state.travel_turns = int(getattr(self.travel_state, "travel_turns", 0)) + int(max(1, day_cost))
         self.travel_state.route_progress = 0
+        self._append_player_event(
+            "expedition.returned",
+            category="expedition",
+            title="Returned to Town",
+            payload={"return_location": "town", "day_cost": int(day_cost)},
+            refs={"hex": [0, 0]},
+        )
         self.ui.title("Return to Town")
         self.ui.log(f"Travel time: {day_cost} day(s).")
         for pc in self.party.pcs():
@@ -2422,7 +2442,23 @@ class Game:
         poi = hx.get("poi") if isinstance(hx, dict) else None
         if not poi:
             return CommandResult(status="info", messages=("There is nothing notable here.",))
-        self.emit("poi_investigation_started", poi_type=poi.get("type"), poi_name=poi.get("name"))
+        q, r = int(self.party_hex[0]), int(self.party_hex[1])
+        poi_type = str(poi.get("type") or "poi")
+        poi_name = str(poi.get("name") or "Point of Interest")
+        poi_id = str(poi.get("id") or f"hex:{q},{r}:{poi_type}")
+        if not bool(poi.get("explored", False)):
+            poi["explored"] = True
+            if isinstance(hx, dict):
+                hx["poi"] = poi
+                self.world_hexes[f"{q},{r}"] = hx
+            self._append_player_event(
+                "poi.explored",
+                category="expedition",
+                title=f"Explored {poi_name}",
+                payload={"poi_id": poi_id, "poi_type": poi_type, "poi_name": poi_name},
+                refs={"poi_id": poi_id, "hex": [q, r]},
+            )
+        self.emit("poi_investigation_started", poi_type=poi_type, poi_name=poi_name)
         self._handle_current_hex_poi()
         return CommandResult(status="ok")
 
@@ -2490,6 +2526,17 @@ class Game:
             self._passive_room_entry_checks(r0)
 
         self.travel_state.location = "dungeon"
+        self._append_player_event(
+            "expedition.departed",
+            category="expedition",
+            title="Expedition departed",
+            payload={
+                "destination_type": str((poi or {}).get("type") or "dungeon_entrance"),
+                "destination_id": str((poi or {}).get("id") or f"hex:{int(self.party_hex[0])},{int(self.party_hex[1])}:dungeon_entrance"),
+                "destination_name": str((poi or {}).get("name") or "Dungeon Entrance"),
+            },
+            refs={"hex": [int(self.party_hex[0]), int(self.party_hex[1])]},
+        )
         self.emit("dungeon_entered", room_id=int(self.current_room_id), expeditions=int(self.expeditions))
         return CommandResult(status="ok")
 
@@ -3282,7 +3329,16 @@ class Game:
             return CommandResult(status="error", messages=("Invalid stairs direction.",))
 
         # Keep legacy depth-scaled systems coherent with active dungeon level.
+        prev_depth = int(getattr(self, "dungeon_depth", 1) or 1)
         self.dungeon_depth = int(self.dungeon_level)
+        if int(self.dungeon_depth) > int(prev_depth):
+            self._append_player_event(
+                "dungeon.depth_reached",
+                category="expedition",
+                title=f"Reached dungeon depth {int(self.dungeon_depth)}",
+                payload={"depth": int(self.dungeon_depth)},
+                refs={"hex": [int(self.party_hex[0]), int(self.party_hex[1])]},
+            )
 
         # Instance-driven (P6.1): do not swap per-level room caches.
         # Rooms are keyed by id in the blueprint, and 'level' maps to blueprint floors.
@@ -4246,6 +4302,17 @@ class Game:
                 self.gold += int(c.get("reward_gp", 0))
                 self.adjust_rep(c.get("faction_id"), int(c.get("rep_success", 5)))
                 self.ui.log(f"Contract completed: {c.get('title')} @ {self._contract_destination_label(c)} (+{c.get('reward_gp')} gp)")
+                self._append_player_event(
+                    "contract.completed",
+                    category="expedition",
+                    title=f"Completed contract: {str(c.get('title') or 'Contract')}",
+                    payload={
+                        "cid": str(c.get("cid") or ""),
+                        "title": str(c.get("title") or "Contract"),
+                        "reward_gp": int(c.get("reward_gp", 0) or 0),
+                    },
+                    refs={"cid": str(c.get("cid") or "")},
+                )
                 changed = True
 
         if changed:
@@ -6475,11 +6542,14 @@ class Game:
         self.district_notes = list(rows)
         return rows
 
+    def _journal_expeditions(self) -> list[dict[str, Any]]:
+        return project_expeditions_from_events(getattr(self, "event_history", []))
+
     def view_journal(self):
         """Show discoveries, rumors, and active district objectives."""
         while True:
-            c = self.ui.choose("Rumors & Discoveries", ["View Discoveries", "View Rumors", "View District Objectives", "View Dungeon Clues", "Back"])
-            if c == 4:
+            c = self.ui.choose("Rumors & Discoveries", ["View Discoveries", "View Rumors", "View District Objectives", "View Dungeon Clues", "View Expedition History", "Back"])
+            if c == 5:
                 return
             if c == 0:
                 discoveries = self._journal_discoveries()
@@ -6520,7 +6590,7 @@ class Game:
                     self.ui.log(
                         f"  District clue: {e.get('target_hint')} | From here: {e.get('from_current')} | Reward: {e.get('reward_gp')} gp"
                     )
-            else:
+            elif c == 3:
                 clues = self._journal_clues()
                 if not clues:
                     self.ui.log('No dungeon clues yet.')
@@ -6528,6 +6598,14 @@ class Game:
                 self.ui.title('Dungeon Clues')
                 for e in clues[-30:][::-1]:
                     self.ui.log(f"Day {e.get('day')} | L{e.get('level')} room {e.get('room_id')} | {e.get('text')}")
+            else:
+                rows = self._journal_expeditions()
+                if not rows:
+                    self.ui.log('No expedition history yet.')
+                    continue
+                self.ui.title('Expedition History')
+                for e in rows[-30:][::-1]:
+                    self.ui.log(f"Day {e.get('day')} {self._watch_name_of(e.get('watch', 0))} | {e.get('title')}")
 
     
     def _wilderness_encounter_check(self, hx: dict[str, Any], *, encounter_mod: int = 0):

--- a/sww/travel_state.py
+++ b/sww/travel_state.py
@@ -20,6 +20,8 @@ class TravelState:
     travel_turns: int = 0
     route_progress: int = 0
     wilderness_clock_turns: int = 0
+    encounter_clock_ticks: int = 0
+    encounter_next_check_tick: int = 1
     condition_started_clock: int = 0
     travel_condition: str = "clear"
 
@@ -33,6 +35,11 @@ class TravelState:
         de = max(0, int(encounter_ticks or 0))
         self.travel_turns = int(self.travel_turns or 0) + dt
         self.wilderness_clock_turns = int(self.wilderness_clock_turns or 0) + dt + dw + de
+        self.encounter_clock_ticks = int(getattr(self, "encounter_clock_ticks", 0) or 0) + de
+        next_tick = int(getattr(self, "encounter_next_check_tick", 1) or 1)
+        if next_tick <= int(self.encounter_clock_ticks):
+            next_tick = int(self.encounter_clock_ticks) + 1
+        self.encounter_next_check_tick = max(1, next_tick)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -40,6 +47,8 @@ class TravelState:
             "travel_turns": int(self.travel_turns or 0),
             "route_progress": int(self.route_progress or 0),
             "wilderness_clock_turns": int(self.wilderness_clock_turns or 0),
+            "encounter_clock_ticks": int(getattr(self, "encounter_clock_ticks", 0) or 0),
+            "encounter_next_check_tick": int(getattr(self, "encounter_next_check_tick", 1) or 1),
             "condition_started_clock": int(self.condition_started_clock or 0),
             "travel_condition": str(self.travel_condition or "clear"),
         }
@@ -64,6 +73,14 @@ class TravelState:
         except Exception:
             wilderness_clock_turns = 0
         try:
+            encounter_clock_ticks = int(data.get("encounter_clock_ticks", 0) or 0)
+        except Exception:
+            encounter_clock_ticks = 0
+        try:
+            encounter_next_check_tick = int(data.get("encounter_next_check_tick", 1) or 1)
+        except Exception:
+            encounter_next_check_tick = 1
+        try:
             condition_started_clock = int(data.get("condition_started_clock", 0) or 0)
         except Exception:
             condition_started_clock = 0
@@ -71,12 +88,16 @@ class TravelState:
         if travel_condition not in ("clear", "wind", "rain", "fog"):
             travel_condition = "clear"
         wilderness_clock_turns = max(0, wilderness_clock_turns)
+        encounter_clock_ticks = max(0, encounter_clock_ticks)
+        encounter_next_check_tick = max(encounter_clock_ticks + 1, max(1, encounter_next_check_tick))
         condition_started_clock = max(0, min(condition_started_clock, wilderness_clock_turns))
         return cls(
             location=location,
             travel_turns=max(0, travel_turns),
             route_progress=max(0, route_progress),
             wilderness_clock_turns=wilderness_clock_turns,
+            encounter_clock_ticks=encounter_clock_ticks,
+            encounter_next_check_tick=encounter_next_check_tick,
             condition_started_clock=condition_started_clock,
             travel_condition=travel_condition,
         )

--- a/tests/test_contract_completion_feedback.py
+++ b/tests/test_contract_completion_feedback.py
@@ -62,6 +62,7 @@ def test_return_to_town_surfaces_completion_coherently_with_destination():
     g._check_contracts_on_town_arrival()
 
     assert _has_line(g, "Contract completed: Job C2 @ Dungeon Entrance")
+    assert any(str(e.get("type") or "") == "contract.completed" and str((e.get("payload") or {}).get("cid") or "") == "C2" for e in (g.event_history or []))
     active = [x for x in (g.active_contracts or []) if str(x.get("cid") or "") == "C2"]
     assert not active
 

--- a/tests/test_journal_event_history.py
+++ b/tests/test_journal_event_history.py
@@ -235,3 +235,55 @@ def test_projection_order_stable_after_normalization():
     rumors = g._journal_rumors()
     hints = [str(r.get("hint") or "") for r in rumors]
     assert hints[:3] == ["first", "second", "third"]
+
+
+def test_expedition_events_emit_and_project_across_loop():
+    g = _new_game(seed=2600)
+    g._wilderness_encounter_check = lambda hx, encounter_mod=0: None
+
+    assert g._cmd_enter_dungeon().ok
+    room = g._ensure_room(g.current_room_id)
+    room.setdefault("stairs", {})["down"] = True
+    assert g._cmd_dungeon_use_stairs("down").ok
+    assert g._cmd_dungeon_leave().ok
+    g.party_hex = (2, 0)
+    g.world_hexes["2,0"] = {
+        "q": 2,
+        "r": 0,
+        "terrain": "clear",
+        "poi": {"id": "poi:test:ruins", "type": "ruins", "name": "Test Ruins", "resolved": True},
+    }
+    assert g._cmd_investigate_current_location().ok
+    assert g._cmd_step_toward_town().ok
+    assert g._cmd_return_to_town().ok
+
+    types = [str(e.get("type") or "") for e in (g.event_history or [])]
+    assert "expedition.departed" in types
+    assert "dungeon.depth_reached" in types
+    assert "poi.explored" in types
+    assert "expedition.returned" in types
+
+    rows = g._journal_expeditions()
+    row_types = [str(r.get("type") or "") for r in rows]
+    assert "expedition.departed" in row_types
+    assert "dungeon.depth_reached" in row_types
+    assert "poi.explored" in row_types
+    assert "expedition.returned" in row_types
+
+
+def test_expedition_event_history_persists_save_load():
+    g = _new_game(seed=2610)
+    g._wilderness_encounter_check = lambda hx, encounter_mod=0: None
+
+    assert g._cmd_enter_dungeon().ok
+    assert g._cmd_dungeon_leave().ok
+    assert g._cmd_return_to_town().ok
+
+    data = game_to_dict(g)
+    g2 = _new_game(seed=2611)
+    apply_game_dict(g2, data)
+
+    rows = g2._journal_expeditions()
+    row_types = [str(r.get("type") or "") for r in rows]
+    assert "expedition.departed" in row_types
+    assert "expedition.returned" in row_types


### PR DESCRIPTION
### Motivation

- Add structured expedition telemetry so departures, returns, POI exploration and dungeon depth milestones are recorded in the event history for journaling and save/load fidelity.
- Track lightweight wilderness encounter clock state so encounter checks can be deterministic and survive save/load.

### Description

- Added `project_expeditions_from_events` to `sww/events.py` to project expedition-related events (`expedition.departed`, `expedition.returned`, `poi.explored`, `dungeon.depth_reached`, `contract.completed`) into a simple row list.
- Emit expedition events in key places: on dungeon entry (`expedition.departed`), when reaching new dungeon depth (`dungeon.depth_reached`), when investigating/exploring a POI (`poi.explored`), and when completing a contract (`contract.completed`) in `sww/game.py`.
- Introduced encounter clock plumbing: new helper `_wilderness_encounter_due` and updated `TravelState` with fields `encounter_clock_ticks` and `encounter_next_check_tick`, updated `advance_clock` logic to maintain those, and threaded `advance_clock` calls from return-to-town to update clocks.
- Wired expedition projection into the journal UI via `_journal_expeditions` and added a "View Expedition History" option in `view_journal`.

### Testing

- Added unit tests in `tests/test_journal_event_history.py` to assert expedition events are emitted, projected in `_journal_expeditions`, and persist across save/load, and updated `tests/test_contract_completion_feedback.py` to check `contract.completed` is appended; these tests were run as part of the change and passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b168f6b9448328933c5e5aae3ea419)