### PR TITLE
combat/log clarity polish: normalize round, action, and status messaging

### DIFF
--- a/sww/battle_events.py
+++ b/sww/battle_events.py
@@ -99,24 +99,28 @@ def format_event(e: BattleEvent) -> str:
         return f"{d.get('unit_id', '?')} takes cover."
     if k == "ATTACK":
         mode = d.get("mode", "")
-        res = d.get("result", None)
-        rr = f" [{res}]" if res else ""
+        res = str(d.get("result", "") or "").strip().lower()
         mm = f" ({mode})" if mode else ""
         roll = d.get("roll", None)
         total = d.get("total", None)
         need = d.get("need", None)
-        rt = ""
+        details = ""
         if roll is not None and total is not None and need is not None:
-            rt = f" (roll {roll} → {total} vs {need})"
+            details = f" (roll {roll} → {total} vs {need})"
         elif roll is not None:
-            rt = f" (roll {roll})"
-        return f"{d.get('attacker_id', '?')} attacks {d.get('target_id', '?')}{mm}{rr}{rt}."
+            details = f" (roll {roll})"
+        if res:
+            return f"{d.get('attacker_id', '?')} attacks {d.get('target_id', '?')}{mm}: {res}.{details}"
+        return f"{d.get('attacker_id', '?')} attacks {d.get('target_id', '?')}{mm}.{details}"
     if k == "DAMAGE":
         hp = d.get("hp", None)
         hpmax = d.get("hp_max", None)
         tail = ""
         if hp is not None and hpmax is not None:
             tail = f" (HP {hp}/{hpmax})"
+        src = d.get("source_id", None)
+        if src:
+            return f"{src} deals {d.get('amount', 0)} damage to {d.get('target_id', '?')}.{tail}"
         return f"{d.get('target_id', '?')} takes {d.get('amount', 0)} damage.{tail}"
 
     if k == "HEAL":
@@ -131,15 +135,15 @@ def format_event(e: BattleEvent) -> str:
         roll = d.get("roll", None)
         need = d.get("need", None)
         res = d.get("result", None)
-        rr = f" [{res}]" if res else ""
+        rr = f": {res}" if res else ""
         rt = ""
         if roll is not None and need is not None:
             rt = f" (roll {roll} vs {need})"
         sp = f" vs {spell}" if spell else ""
-        return f"{d.get('unit_id','?')} saves ({d.get('save','?')}){sp}.{rr}{rt}"
+        return f"{d.get('unit_id','?')} saves ({d.get('save','?')}){sp}{rr}.{rt}"
 
     if k == "UNIT_DIED":
-        return f"{d.get('unit_id', '?')} is slain!"
+        return f"{d.get('unit_id', '?')} dies."
     if k == "OPPORTUNITY_ATTACK_TRIGGERED":
         return f"{d.get('attacker_id', '?')} makes an opportunity attack on {d.get('target_id', '?')}."
     if k == "SPELL_CAST":
@@ -153,7 +157,7 @@ def format_event(e: BattleEvent) -> str:
         return f"{d.get('spell','?')} affects {d.get('count',0)} target(s){dt}."
 
     if k == "ROUND_STARTED":
-        return f"Round {d.get('round_no', '?')} (initiative: {d.get('side_first', '?')} first)."
+        return f"Round {d.get('round_no', '?')} begins (initiative: {d.get('side_first', '?')} first)."
     if k == "PHASE_STARTED":
         return f"Phase: {d.get('phase', '?')}"
     if k == "ACTION_DECLARED":
@@ -186,7 +190,7 @@ def format_event(e: BattleEvent) -> str:
     if k == "UNIT_FALLBACK":
         return f"{d.get('unit_id','?')} falls back!"
     if k == "UNIT_ROUTED":
-        return f"{d.get('unit_id','?')} routs!"
+        return f"{d.get('unit_id','?')} flees!"
     if k == "UNIT_SURRENDERED":
         return f"{d.get('unit_id','?')} surrenders!"
 
@@ -208,11 +212,18 @@ def format_event(e: BattleEvent) -> str:
     if k == "ITEM_THROWN":
         return f"{d.get('unit','?')} throws {d.get('item','?')}."
     if k == "EFFECT_APPLIED":
-        return f"{d.get('tgt','?')} gains {d.get('kind','?')}."
+        return f"{d.get('tgt','?')} is affected by {d.get('kind','?')}."
+    if k == "EFFECT_REFRESHED":
+        return f"{d.get('kind','?').title()} on {d.get('tgt','?')} is refreshed."
     if k == "EFFECT_REMOVED":
-        return f"{d.get('tgt','?')} loses {d.get('kind','?')}."
+        reason = str(d.get("reason", "") or "").strip()
+        if reason in ("resisted", "save_success"):
+            return f"{d.get('tgt','?')} resists {d.get('kind','?')}."
+        if reason:
+            return f"{d.get('kind','?').title()} is removed from {d.get('tgt','?')} ({reason})."
+        return f"{d.get('kind','?').title()} is removed from {d.get('tgt','?')}."
     if k == "EFFECT_EXPIRED":
-        return f"{d.get('tgt','?')}'s {d.get('kind','?')} ends."
+        return f"{d.get('kind','?').title()} on {d.get('tgt','?')} expires."
     if k == "TERRAIN_CHANGED":
         return f"Terrain changed at ({d.get('x','?')},{d.get('y','?')}): {d.get('tile','?')}."
     if k in ("XP_AWARDED","XP_EARNED"):

--- a/sww/effects.py
+++ b/sww/effects.py
@@ -109,6 +109,8 @@ class EffectsManager:
                 if callable(be) and bool(getattr(self.game, "_battle_buffer_active", False)):
                     if name == "effect_applied":
                         be("EFFECT_APPLIED", tgt=str((data or {}).get("target", "")), kind=str((data or {}).get("kind", "")))
+                    elif name == "effect_refreshed":
+                        be("EFFECT_REFRESHED", tgt=str((data or {}).get("target", "")), kind=str((data or {}).get("kind", "")))
                     elif name == "effect_removed":
                         reason = str((data or {}).get("reason", ""))
                         kind = str((data or {}).get("kind", ""))
@@ -255,6 +257,10 @@ class EffectsManager:
                     container[existing_id] = old
                     inst = old
                     inst["instance_id"] = existing_id
+                    self._emit(
+                        "effect_refreshed",
+                        {"kind": kind, "target": target.name, "instance_id": existing_id, "source": inst.get("source")},
+                    )
 
         # Store and apply
         container[instance_id] = inst

--- a/tests/test_battle_events_formatting.py
+++ b/tests/test_battle_events_formatting.py
@@ -1,0 +1,38 @@
+from sww.battle_events import BattleEvent, evt, format_event
+
+
+def test_round_header_and_attack_damage_formatting():
+    assert format_event(evt("ROUND_STARTED", round_no=3, side_first="party")) == "Round 3 begins (initiative: party first)."
+    assert (
+        format_event(
+            evt(
+                "ATTACK",
+                attacker_id="Aldric",
+                target_id="Goblin",
+                result="miss",
+                roll=7,
+                total=9,
+                need=13,
+                mode="melee",
+            )
+        )
+        == "Aldric attacks Goblin (melee): miss. (roll 7 → 9 vs 13)"
+    )
+    assert (
+        format_event(evt("DAMAGE", source_id="Goblin", target_id="Mira", amount=3, hp=4, hp_max=7))
+        == "Goblin deals 3 damage to Mira. (HP 4/7)"
+    )
+
+
+def test_effect_and_save_and_outcome_formatting():
+    assert format_event(BattleEvent("EFFECT_APPLIED", {"tgt": "Goblin", "kind": "poisoned"})) == "Goblin is affected by poisoned."
+    assert format_event(BattleEvent("EFFECT_REFRESHED", {"tgt": "Bandit", "kind": "sleep"})) == "Sleep on Bandit is refreshed."
+    assert format_event(BattleEvent("EFFECT_EXPIRED", {"tgt": "Bandit", "kind": "sleep"})) == "Sleep on Bandit expires."
+    assert format_event(BattleEvent("EFFECT_REMOVED", {"tgt": "Aldric", "kind": "bless"})) == "Bless is removed from Aldric."
+    assert format_event(BattleEvent("EFFECT_REMOVED", {"tgt": "Orc", "kind": "paralysis", "reason": "resisted"})) == "Orc resists paralysis."
+    assert (
+        format_event(evt("SAVE_THROW", unit_id="Orc", save="poison", spell="Poison", result="success", roll=14, need=13))
+        == "Orc saves (poison) vs Poison: success. (roll 14 vs 13)"
+    )
+    assert format_event(evt("UNIT_DIED", unit_id="Goblin")) == "Goblin dies."
+    assert format_event(evt("UNIT_ROUTED", unit_id="Bandit")) == "Bandit flees!"


### PR DESCRIPTION
### Motivation
- Improve combat log readability and scanability without changing gameplay mechanics or initiative order.
- Provide consistent, actor-first phrasing and clearer lifecycle signals for status effects so players can answer "what happened" and "why" more easily.

### Description
- Normalized round header formatting by making `ROUND_STARTED` read as `Round N begins (initiative: X first).`.
- Standardized attack/result and damage messaging in `sww/battle_events.py` so `ATTACK` reads `Attacker attacks Target (mode): result. (roll ...)` and `DAMAGE` includes a `source_id` when available (`Source deals N damage to Target.`).
- Made `SAVE_THROW` punctuation consistent and simplified death/rout text to `X dies.` and `X flees!` respectively.
- Improved status lifecycle clarity by changing `EFFECT_APPLIED` wording, adding an `EFFECT_REFRESHED` event and formatter, and making `EFFECT_REMOVED` reason-aware (resisted/save_success → `Target resists ...`, explicit removal reasons included); expired text now reads `Effect on Target expires.`.
- Emitted a new `effect_refreshed` internal event from the effects manager and mirrored it into buffered battle events so refreshes appear in the round summary (`sww/effects.py`).
- Kept all changes limited to logging/formatting and event emission; no combat rules, balancing, or initiative flow were modified.
- Files changed: `sww/battle_events.py`, `sww/effects.py`, and added tests at `tests/test_battle_events_formatting.py`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_battle_events_formatting.py tests/test_combat_rules_and_status.py` and observed `8 passed` for the two-file run after fixes.
- Ran `PYTHONPATH=. pytest -q tests/test_*combat* -q` which completed with the combat-related tests passing (`......`).
- Ran `PYTHONPATH=. pytest -q tests/test_*status* -q` which completed with the status-related tests passing (`......`).
- Attempted `PYTHONPATH=. pytest -q tests/test_*replay* -q` which reported no matching tests in this repository pattern and was skipped as out-of-scope for this change.
- All tests affected by formatting and status lifecycle changes passed locally after updates to mirror `effect_refreshed` and test adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b172e26b0c83288a19db07848bc51d)