### PR TITLE
Improve battle event formatting, emit effect_refreshed, and add expedition recap on return to town

### DIFF
--- a/sww/battle_events.py
+++ b/sww/battle_events.py
@@ -99,24 +99,28 @@ def format_event(e: BattleEvent) -> str:
         return f"{d.get('unit_id', '?')} takes cover."
     if k == "ATTACK":
         mode = d.get("mode", "")
-        res = d.get("result", None)
-        rr = f" [{res}]" if res else ""
+        res = str(d.get("result", "") or "").strip().lower()
         mm = f" ({mode})" if mode else ""
         roll = d.get("roll", None)
         total = d.get("total", None)
         need = d.get("need", None)
-        rt = ""
+        details = ""
         if roll is not None and total is not None and need is not None:
-            rt = f" (roll {roll} → {total} vs {need})"
+            details = f" (roll {roll} → {total} vs {need})"
         elif roll is not None:
-            rt = f" (roll {roll})"
-        return f"{d.get('attacker_id', '?')} attacks {d.get('target_id', '?')}{mm}{rr}{rt}."
+            details = f" (roll {roll})"
+        if res:
+            return f"{d.get('attacker_id', '?')} attacks {d.get('target_id', '?')}{mm}: {res}.{details}"
+        return f"{d.get('attacker_id', '?')} attacks {d.get('target_id', '?')}{mm}.{details}"
     if k == "DAMAGE":
         hp = d.get("hp", None)
         hpmax = d.get("hp_max", None)
         tail = ""
         if hp is not None and hpmax is not None:
             tail = f" (HP {hp}/{hpmax})"
+        src = d.get("source_id", None)
+        if src:
+            return f"{src} deals {d.get('amount', 0)} damage to {d.get('target_id', '?')}.{tail}"
         return f"{d.get('target_id', '?')} takes {d.get('amount', 0)} damage.{tail}"
 
     if k == "HEAL":
@@ -131,15 +135,15 @@ def format_event(e: BattleEvent) -> str:
         roll = d.get("roll", None)
         need = d.get("need", None)
         res = d.get("result", None)
-        rr = f" [{res}]" if res else ""
+        rr = f": {res}" if res else ""
         rt = ""
         if roll is not None and need is not None:
             rt = f" (roll {roll} vs {need})"
         sp = f" vs {spell}" if spell else ""
-        return f"{d.get('unit_id','?')} saves ({d.get('save','?')}){sp}.{rr}{rt}"
+        return f"{d.get('unit_id','?')} saves ({d.get('save','?')}){sp}{rr}.{rt}"
 
     if k == "UNIT_DIED":
-        return f"{d.get('unit_id', '?')} is slain!"
+        return f"{d.get('unit_id', '?')} dies."
     if k == "OPPORTUNITY_ATTACK_TRIGGERED":
         return f"{d.get('attacker_id', '?')} makes an opportunity attack on {d.get('target_id', '?')}."
     if k == "SPELL_CAST":
@@ -153,7 +157,7 @@ def format_event(e: BattleEvent) -> str:
         return f"{d.get('spell','?')} affects {d.get('count',0)} target(s){dt}."
 
     if k == "ROUND_STARTED":
-        return f"Round {d.get('round_no', '?')} (initiative: {d.get('side_first', '?')} first)."
+        return f"Round {d.get('round_no', '?')} begins (initiative: {d.get('side_first', '?')} first)."
     if k == "PHASE_STARTED":
         return f"Phase: {d.get('phase', '?')}"
     if k == "ACTION_DECLARED":
@@ -186,7 +190,7 @@ def format_event(e: BattleEvent) -> str:
     if k == "UNIT_FALLBACK":
         return f"{d.get('unit_id','?')} falls back!"
     if k == "UNIT_ROUTED":
-        return f"{d.get('unit_id','?')} routs!"
+        return f"{d.get('unit_id','?')} flees!"
     if k == "UNIT_SURRENDERED":
         return f"{d.get('unit_id','?')} surrenders!"
 
@@ -208,11 +212,18 @@ def format_event(e: BattleEvent) -> str:
     if k == "ITEM_THROWN":
         return f"{d.get('unit','?')} throws {d.get('item','?')}."
     if k == "EFFECT_APPLIED":
-        return f"{d.get('tgt','?')} gains {d.get('kind','?')}."
+        return f"{d.get('tgt','?')} is affected by {d.get('kind','?')}."
+    if k == "EFFECT_REFRESHED":
+        return f"{d.get('kind','?').title()} on {d.get('tgt','?')} is refreshed."
     if k == "EFFECT_REMOVED":
-        return f"{d.get('tgt','?')} loses {d.get('kind','?')}."
+        reason = str(d.get("reason", "") or "").strip()
+        if reason in ("resisted", "save_success"):
+            return f"{d.get('tgt','?')} resists {d.get('kind','?')}."
+        if reason:
+            return f"{d.get('kind','?').title()} is removed from {d.get('tgt','?')} ({reason})."
+        return f"{d.get('kind','?').title()} is removed from {d.get('tgt','?')}."
     if k == "EFFECT_EXPIRED":
-        return f"{d.get('tgt','?')}'s {d.get('kind','?')} ends."
+        return f"{d.get('kind','?').title()} on {d.get('tgt','?')} expires."
     if k == "TERRAIN_CHANGED":
         return f"Terrain changed at ({d.get('x','?')},{d.get('y','?')}): {d.get('tile','?')}."
     if k in ("XP_AWARDED","XP_EARNED"):

--- a/sww/effects.py
+++ b/sww/effects.py
@@ -109,6 +109,8 @@ class EffectsManager:
                 if callable(be) and bool(getattr(self.game, "_battle_buffer_active", False)):
                     if name == "effect_applied":
                         be("EFFECT_APPLIED", tgt=str((data or {}).get("target", "")), kind=str((data or {}).get("kind", "")))
+                    elif name == "effect_refreshed":
+                        be("EFFECT_REFRESHED", tgt=str((data or {}).get("target", "")), kind=str((data or {}).get("kind", "")))
                     elif name == "effect_removed":
                         reason = str((data or {}).get("reason", ""))
                         kind = str((data or {}).get("kind", ""))
@@ -255,6 +257,10 @@ class EffectsManager:
                     container[existing_id] = old
                     inst = old
                     inst["instance_id"] = existing_id
+                    self._emit(
+                        "effect_refreshed",
+                        {"kind": kind, "target": target.name, "instance_id": existing_id, "source": inst.get("source")},
+                    )
 
         # Store and apply
         container[instance_id] = inst

--- a/sww/game.py
+++ b/sww/game.py
@@ -2418,15 +2418,19 @@ class Game:
         )
         self.travel_state.location = "town"
         self.travel_state.route_progress = 0
-        self._append_player_event(
+        returned_evt = self._append_player_event(
             "expedition.returned",
             category="expedition",
             title="Returned to Town",
             payload={"return_location": "town", "day_cost": int(day_cost)},
             refs={"hex": [0, 0]},
         )
+        # Resolve contracts before recap so outcomes are reflected in the same expedition window.
+        self._check_contracts_on_town_arrival()
         self.ui.title("Return to Town")
         self.ui.log(f"Travel time: {day_cost} day(s).")
+        for ln in self._build_expedition_recap_lines(returned_eid=int((returned_evt or {}).get("eid", 0) or 0)):
+            self.ui.log(ln)
         for pc in self.party.pcs():
             next_xp = int(self.xp_threshold_for_class(getattr(pc, "cls", "Fighter"), int(getattr(pc, "level", 1) or 1) + 1))
             cur_xp = int(getattr(pc, "xp", 0) or 0)
@@ -2436,6 +2440,104 @@ class Game:
             self.ui.log(f"- {pc.name}: Lv{pc.level} XP {cur_xp}/{next_xp} (to next: {remain}) HP {hp}/{hp_max}")
         day_txt = f"{day_cost} day" + ("s" if day_cost != 1 else "")
         return CommandResult(status="ok", messages=(f"You return to Town. ({day_txt})",))
+
+    def _build_expedition_recap_lines(self, *, returned_eid: int | None = None) -> list[str]:
+        """Build concise recap lines for the most recent expedition event window."""
+        rows = [e for e in (getattr(self, "event_history", []) or []) if isinstance(e, dict)]
+        if not rows:
+            return []
+        rows.sort(key=lambda e: int((e or {}).get("eid", 0) or 0))
+
+        end_eid = int(returned_eid or 0)
+        if end_eid <= 0:
+            for ev in reversed(rows):
+                if str((ev or {}).get("type") or "") == "expedition.returned":
+                    end_eid = int((ev or {}).get("eid", 0) or 0)
+                    break
+        if end_eid <= 0:
+            return []
+
+        start_ev = None
+        for ev in reversed(rows):
+            eid = int((ev or {}).get("eid", 0) or 0)
+            if eid >= end_eid:
+                continue
+            if str((ev or {}).get("type") or "") == "expedition.departed":
+                start_ev = ev
+                break
+        if start_ev is None:
+            return []
+
+        start_eid = int((start_ev or {}).get("eid", 0) or 0)
+        window = [ev for ev in rows if int((ev or {}).get("eid", 0) or 0) > start_eid and int((ev or {}).get("eid", 0) or 0) <= end_eid]
+        if not window:
+            return []
+
+        depth_max = 0
+        pois: list[str] = []
+        contracts: list[str] = []
+        rumors = 0
+        discoveries = 0
+        for ev in window:
+            et = str((ev or {}).get("type") or "")
+            payload = dict((ev or {}).get("payload") or {})
+            if et == "dungeon.depth_reached":
+                try:
+                    depth_max = max(depth_max, int(payload.get("depth", 0) or 0))
+                except Exception:
+                    pass
+            elif et == "poi.explored":
+                nm = str(payload.get("poi_name") or (ev or {}).get("title") or "").strip()
+                if nm and nm not in pois:
+                    pois.append(nm)
+            elif et == "contract.completed":
+                nm = str(payload.get("title") or "Contract").strip()
+                if nm and nm not in contracts:
+                    contracts.append(nm)
+            elif et == "rumor.learned":
+                rumors += 1
+            elif et == "discovery.recorded":
+                discoveries += 1
+
+        start_payload = dict((start_ev or {}).get("payload") or {})
+        start_gold = int(start_payload.get("gold_start", int(getattr(self, "gold", 0) or 0)) or 0)
+        start_xp_total = int(start_payload.get("party_xp_total", 0) or 0)
+        gold_gain = int(getattr(self, "gold", 0) or 0) - int(start_gold)
+        xp_total_now = sum(int(getattr(pc, "xp", 0) or 0) for pc in (self.party.pcs() or []))
+        xp_gain = int(xp_total_now) - int(start_xp_total)
+
+        injured = 0
+        fallen = 0
+        for pc in (self.party.pcs() or []):
+            hp = int(getattr(pc, "hp", 0) or 0)
+            hp_max = int(getattr(pc, "hp_max", 0) or 0)
+            if hp <= 0:
+                fallen += 1
+            elif hp < hp_max:
+                injured += 1
+
+        lines = ["Expedition Recap", "----------------"]
+        if depth_max > 0:
+            lines.append(f"Depth reached: {depth_max}")
+        if pois:
+            lines.append(f"POIs explored: {', '.join(pois[:3])}{'...' if len(pois) > 3 else ''}")
+        if contracts:
+            lines.append(f"Contracts completed: {', '.join(contracts[:3])}{'...' if len(contracts) > 3 else ''}")
+        if gold_gain:
+            lines.append(f"Gold gained: {gold_gain}")
+        if xp_gain:
+            lines.append(f"XP gained: {xp_gain}")
+        if discoveries:
+            lines.append(f"New discoveries: {discoveries}")
+        if rumors:
+            lines.append(f"New rumors: {rumors}")
+        if fallen > 0:
+            lines.append(f"Party condition: {fallen} fallen, {injured} injured")
+        elif injured > 0:
+            lines.append(f"Party condition: {injured} injured")
+        else:
+            lines.append("Party condition: ready")
+        return lines
 
     def _cmd_investigate_current_location(self) -> CommandResult:
         hx = self._ensure_current_hex()
@@ -2534,6 +2636,8 @@ class Game:
                 "destination_type": str((poi or {}).get("type") or "dungeon_entrance"),
                 "destination_id": str((poi or {}).get("id") or f"hex:{int(self.party_hex[0])},{int(self.party_hex[1])}:dungeon_entrance"),
                 "destination_name": str((poi or {}).get("name") or "Dungeon Entrance"),
+                "gold_start": int(getattr(self, "gold", 0) or 0),
+                "party_xp_total": int(sum(int(getattr(pc, "xp", 0) or 0) for pc in (self.party.pcs() or []))),
             },
             refs={"hex": [int(self.party_hex[0]), int(self.party_hex[1])]},
         )

--- a/tests/test_battle_events_formatting.py
+++ b/tests/test_battle_events_formatting.py
@@ -1,0 +1,38 @@
+from sww.battle_events import BattleEvent, evt, format_event
+
+
+def test_round_header_and_attack_damage_formatting():
+    assert format_event(evt("ROUND_STARTED", round_no=3, side_first="party")) == "Round 3 begins (initiative: party first)."
+    assert (
+        format_event(
+            evt(
+                "ATTACK",
+                attacker_id="Aldric",
+                target_id="Goblin",
+                result="miss",
+                roll=7,
+                total=9,
+                need=13,
+                mode="melee",
+            )
+        )
+        == "Aldric attacks Goblin (melee): miss. (roll 7 → 9 vs 13)"
+    )
+    assert (
+        format_event(evt("DAMAGE", source_id="Goblin", target_id="Mira", amount=3, hp=4, hp_max=7))
+        == "Goblin deals 3 damage to Mira. (HP 4/7)"
+    )
+
+
+def test_effect_and_save_and_outcome_formatting():
+    assert format_event(BattleEvent("EFFECT_APPLIED", {"tgt": "Goblin", "kind": "poisoned"})) == "Goblin is affected by poisoned."
+    assert format_event(BattleEvent("EFFECT_REFRESHED", {"tgt": "Bandit", "kind": "sleep"})) == "Sleep on Bandit is refreshed."
+    assert format_event(BattleEvent("EFFECT_EXPIRED", {"tgt": "Bandit", "kind": "sleep"})) == "Sleep on Bandit expires."
+    assert format_event(BattleEvent("EFFECT_REMOVED", {"tgt": "Aldric", "kind": "bless"})) == "Bless is removed from Aldric."
+    assert format_event(BattleEvent("EFFECT_REMOVED", {"tgt": "Orc", "kind": "paralysis", "reason": "resisted"})) == "Orc resists paralysis."
+    assert (
+        format_event(evt("SAVE_THROW", unit_id="Orc", save="poison", spell="Poison", result="success", roll=14, need=13))
+        == "Orc saves (poison) vs Poison: success. (roll 14 vs 13)"
+    )
+    assert format_event(evt("UNIT_DIED", unit_id="Goblin")) == "Goblin dies."
+    assert format_event(evt("UNIT_ROUTED", unit_id="Bandit")) == "Bandit flees!"

--- a/tests/test_expedition_recap.py
+++ b/tests/test_expedition_recap.py
@@ -1,0 +1,89 @@
+from sww.game import Game, PC, Stats
+from sww.ui_headless import HeadlessUI
+from sww.save_load import game_to_dict, apply_game_dict
+
+
+def _new_game(seed: int = 30000) -> Game:
+    g = Game(HeadlessUI(), dice_seed=seed, wilderness_seed=seed + 1)
+    g._wilderness_encounter_check = lambda hx, encounter_mod=0: None
+    if not g.party.pcs():
+        g.party.members = [
+            PC(
+                name="Hero",
+                race="Human",
+                hp=6,
+                hp_max=8,
+                ac_desc=9,
+                hd=1,
+                save=15,
+                morale=9,
+                alignment="Neutrality",
+                is_pc=True,
+                cls="Fighter",
+                level=1,
+                xp=0,
+                stats=Stats(10, 10, 10, 10, 10, 10),
+            )
+        ]
+    return g
+
+
+def _append(g: Game, etype: str, payload: dict | None = None, title: str = "") -> dict:
+    return g._append_player_event(
+        etype,
+        category="expedition",
+        title=title or etype,
+        payload=dict(payload or {}),
+        refs={},
+    )
+
+
+def test_expedition_recap_generated_on_return_to_town():
+    g = _new_game()
+    pc = g.party.pcs()[0]
+    pc.xp += 25
+    g.gold += 12
+
+    assert g._cmd_enter_dungeon().ok
+    _append(g, "dungeon.depth_reached", {"depth": 2}, "Reached dungeon depth 2")
+    _append(g, "poi.explored", {"poi_name": "Ruined Shrine"}, "Explored Ruined Shrine")
+
+    assert g._cmd_return_to_town().ok
+
+    assert any("Expedition Recap" in ln for ln in g.ui.lines)
+    assert any("Depth reached: 2" in ln for ln in g.ui.lines)
+    assert any("POIs explored: Ruined Shrine" in ln for ln in g.ui.lines)
+
+
+def test_expedition_recap_uses_event_history_window():
+    g = _new_game(seed=30010)
+
+    d1 = _append(g, "expedition.departed", {"gold_start": 10, "party_xp_total": 100}, "Expedition departed")
+    _append(g, "poi.explored", {"poi_name": "Old Ruins"}, "Explored Old Ruins")
+    _append(g, "expedition.returned", {"day_cost": 1}, "Returned to Town")
+
+    d2 = _append(g, "expedition.departed", {"gold_start": 30, "party_xp_total": 200}, "Expedition departed")
+    _append(g, "poi.explored", {"poi_name": "Sunken Hall"}, "Explored Sunken Hall")
+    r2 = _append(g, "expedition.returned", {"day_cost": 1}, "Returned to Town")
+
+    assert int(d2.get("eid", 0)) > int(d1.get("eid", 0))
+    lines = g._build_expedition_recap_lines(returned_eid=int(r2.get("eid", 0)))
+
+    assert any("POIs explored: Sunken Hall" in ln for ln in lines)
+    assert all("Old Ruins" not in ln for ln in lines)
+
+
+def test_expedition_recap_after_save_load():
+    g = _new_game(seed=30020)
+    _append(g, "expedition.departed", {"gold_start": 100, "party_xp_total": 0}, "Expedition departed")
+    _append(g, "contract.completed", {"title": "Missing Caravan", "reward_gp": 25}, "Completed contract: Missing Caravan")
+    g.gold = 125
+    ret = _append(g, "expedition.returned", {"day_cost": 1}, "Returned to Town")
+
+    data = game_to_dict(g)
+    g2 = _new_game(seed=30021)
+    apply_game_dict(g2, data)
+
+    lines = g2._build_expedition_recap_lines(returned_eid=int(ret.get("eid", 0)))
+    assert any("Contracts completed: Missing Caravan" in ln for ln in lines)
+    assert any("Gold gained: 25" in ln for ln in lines)


### PR DESCRIPTION
### Motivation

- Make battle log messages clearer and more consistent for attacks, damage, saves, and effects so players/readers get concise, human-friendly output.
- Ensure effect refreshes are emitted and mirrored into buffered battle events so refreshes appear in combat logs.
- Provide a concise expedition recap on returning to town using the expedition event window so players immediately see summary outcomes.

### Description

- Updated `sww/battle_events.py` to normalize and expand `ATTACK` output to include result text and roll details, show damage source when present, refine `SAVE_THROW` punctuation, and change several outcome/effect phrasings including `UNIT_DIED`, `UNIT_ROUTED`, `EFFECT_APPLIED`, `EFFECT_REFRESHED`, `EFFECT_REMOVED`, and `EFFECT_EXPIRED`.
- Modified `sww/effects.py` to emit an `effect_refreshed` event when an effect is refreshed and mirror that into buffered battle events alongside `effect_applied`/`effect_removed` handling.
- Added expedition recap generation to `sww/game.py` by recording `gold_start` and `party_xp_total` on `expedition.departed`, calling contract resolution before building the recap, and introducing `_build_expedition_recap_lines` to summarize depth reached, POIs, contracts, gold/xp gains, discoveries, rumors, and party condition; the recap is displayed on return to town.
- Added tests `tests/test_battle_events_formatting.py` and `tests/test_expedition_recap.py` covering the new battle event messages and expedition recap behavior.

### Testing

- Added and ran unit tests in `tests/test_battle_events_formatting.py` which validate updated `format_event` outputs and they passed.
- Added and ran unit tests in `tests/test_expedition_recap.py` which validate recap generation across normal flow and after save/load and they passed.
- Ran the test suite with `pytest tests` to verify integration of the changes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b172e26b0c83288a19db07848bc51d)