### PR TITLE
Add shared wilderness travel context and POI first-time key helpers

### DIFF
--- a/sww/game.py
+++ b/sww/game.py
@@ -19,7 +19,7 @@ from .encounters import EncounterGenerator
 from .equipment import EquipmentDB
 from .ports import UIProtocol
 from .save_load import save_game, load_game, read_save_metadata
-from .wilderness import ensure_hex, neighbors, hex_distance, force_poi
+from .wilderness import ensure_hex, neighbors, hex_distance, force_poi, first_time_poi_resolution_key
 from .travel_state import TravelState, TOWN_HEX, DUNGEON_ENTRANCE_HEX
 from .factions import generate_static_core_factions, assign_territories, generate_static_conflict_clocks, clamp_rep
 from .contracts import generate_contracts, Contract
@@ -2006,6 +2006,28 @@ class Game:
             return (1, 2)
         return (0, 0)
 
+    def resolve_travel_context(self, hx: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Return normalized wilderness travel context for encounter/discovery/rumor logic."""
+        hex_row = hx if isinstance(hx, dict) else self._ensure_current_hex()
+        terrain = str((hex_row or {}).get("terrain", "clear") or "clear")
+        travel_mode = str(getattr(self, "wilderness_travel_mode", "normal") or "normal").lower()
+        _steps, _wps, mode_enc_mod = self._wilderness_travel_params()
+        _wps_mod, terr_enc_mod = self._terrain_travel_mods(terrain)
+        watch_name = self._watch_name()
+        members = list(getattr(getattr(self, "party", None), "members", []) or [])
+        living = list(getattr(getattr(self, "party", None), "living", lambda: [])() or [])
+        low_supplies = int(getattr(self, "rations", 0) or 0) < max(1, len(members))
+        return {
+            "terrain": terrain,
+            "pace": travel_mode,
+            "watch": watch_name,
+            "on_road": terrain == "road",
+            "party_ready": bool(living),
+            "low_supplies": bool(low_supplies),
+            "encounter_mod": int(mode_enc_mod) + int(terr_enc_mod),
+            "discovery_mod": 1 if terrain == "road" else 0,
+        }
+
     def _cmd_travel_direction(self, direction: str) -> CommandResult:
 
 
@@ -2024,7 +2046,7 @@ class Game:
         src = tuple(self.party_hex)
 
 
-        steps, wps, enc_mod = self._wilderness_travel_params()
+        steps, wps, _enc_mod = self._wilderness_travel_params()
 
 
         cur = tuple(self.party_hex)
@@ -2050,15 +2072,15 @@ class Game:
 
             # Destination hex determines travel friction and encounter bias.
             hx2 = self._ensure_current_hex()
-            terrain = str(hx2.get("terrain", "clear"))
-            wps_mod, terr_enc_mod = self._terrain_travel_mods(terrain)
+            ctx = self.resolve_travel_context(hx2)
+            wps_mod, _terr_enc_mod = self._terrain_travel_mods(str(ctx.get("terrain") or "clear"))
             wps_eff = max(1, int(wps) + int(wps_mod))
 
             self._consume_rations(1)
             self._advance_watch(int(wps_eff))
             self._advance_wilderness_clock(travel_turns=1, watch_turns=int(wps_eff), encounter_ticks=1)
             self.travel_state.route_progress = int(getattr(self.travel_state, "route_progress", 0)) + 1
-            self._wilderness_encounter_check(hx2, encounter_mod=int(enc_mod) + int(terr_enc_mod))
+            self._wilderness_encounter_check(hx2, encounter_mod=int(ctx.get("encounter_mod", 0)))
 
 
             # If the party was wiped in an encounter, stop travel chain.
@@ -2101,7 +2123,7 @@ class Game:
         # TravelToHex is an explicit single-step move.
 
 
-        steps, wps, enc_mod = self._wilderness_travel_params()
+        steps, wps, _enc_mod = self._wilderness_travel_params()
 
 
         # Respect travel mode pacing but do not chain beyond the explicit destination.
@@ -2110,15 +2132,15 @@ class Game:
         self.party_hex = dest
 
         hx2 = self._ensure_current_hex()
-        terrain = str(hx2.get("terrain", "clear"))
-        wps_mod, terr_enc_mod = self._terrain_travel_mods(terrain)
+        ctx = self.resolve_travel_context(hx2)
+        wps_mod, _terr_enc_mod = self._terrain_travel_mods(str(ctx.get("terrain") or "clear"))
         wps_eff = max(1, int(wps) + int(wps_mod))
 
         self._consume_rations(1)
         self._advance_watch(int(wps_eff))
         self._advance_wilderness_clock(travel_turns=1, watch_turns=int(wps_eff), encounter_ticks=1)
         self.travel_state.route_progress = int(getattr(self.travel_state, "route_progress", 0)) + 1
-        self._wilderness_encounter_check(hx2, encounter_mod=int(enc_mod) + int(terr_enc_mod))
+        self._wilderness_encounter_check(hx2, encounter_mod=int(ctx.get("encounter_mod", 0)))
 
 
         self.emit("traveled", mode="to_hex", src=src, dest=dest, travel_mode=str(getattr(self,'wilderness_travel_mode','normal')))
@@ -2137,7 +2159,7 @@ class Game:
             return CommandResult(status="error", messages=("You are already at Town.",))
 
 
-        steps, wps, enc_mod = self._wilderness_travel_params()
+        steps, wps, _enc_mod = self._wilderness_travel_params()
 
 
         src = tuple(self.party_hex)
@@ -2185,15 +2207,15 @@ class Game:
             self.party_hex = best
 
             hx2 = self._ensure_current_hex()
-            terrain = str(hx2.get("terrain", "clear"))
-            wps_mod, terr_enc_mod = self._terrain_travel_mods(terrain)
+            ctx = self.resolve_travel_context(hx2)
+            wps_mod, _terr_enc_mod = self._terrain_travel_mods(str(ctx.get("terrain") or "clear"))
             wps_eff = max(1, int(wps) + int(wps_mod))
 
             self._consume_rations(1)
             self._advance_watch(int(wps_eff))
             self._advance_wilderness_clock(travel_turns=1, watch_turns=int(wps_eff), encounter_ticks=1)
             self.travel_state.route_progress = int(getattr(self.travel_state, "route_progress", 0)) + 1
-            self._wilderness_encounter_check(hx2, encounter_mod=int(enc_mod) + int(terr_enc_mod))
+            self._wilderness_encounter_check(hx2, encounter_mod=int(ctx.get("encounter_mod", 0)))
 
 
             if not self.party.living():
@@ -2547,7 +2569,7 @@ class Game:
         q, r = int(self.party_hex[0]), int(self.party_hex[1])
         poi_type = str(poi.get("type") or "poi")
         poi_name = str(poi.get("name") or "Point of Interest")
-        poi_id = str(poi.get("id") or f"hex:{q},{r}:{poi_type}")
+        poi_id = first_time_poi_resolution_key(poi, q=q, r=r, mode="explore")
         if not bool(poi.get("explored", False)):
             poi["explored"] = True
             if isinstance(hx, dict):
@@ -5898,10 +5920,14 @@ class Game:
 
         discovered = bool(existing.get("discovered", False))
         resolved = bool(existing.get("resolved", False))
+        explored = bool(existing.get("explored", False))
+        rumored = bool(existing.get("rumored", False))
 
         if str(existing.get("id") or "") == canonical_id:
             discovered = bool(existing.get("discovered", False))
             resolved = bool(existing.get("resolved", False))
+            explored = bool(existing.get("explored", False))
+            rumored = bool(existing.get("rumored", False))
 
         hx.poi = {
             "id": canonical_id,
@@ -5910,6 +5936,8 @@ class Game:
             "notes": "A known stair descending into the depths near town.",
             "discovered": discovered,
             "resolved": resolved,
+            "explored": explored,
+            "rumored": rumored,
             "canonical": True,
         }
         self.world_hexes[hx.key()] = hx.to_dict()
@@ -5940,6 +5968,7 @@ class Game:
                 "notes": notes,
                 "discovered": bool(existing.get("discovered", False)),
                 "resolved": bool(existing.get("resolved", False)),
+                "explored": bool(existing.get("explored", False)),
                 "rumored": bool(existing.get("rumored", False)),
                 "secondary": True,
             }
@@ -6050,7 +6079,7 @@ class Game:
             return
         kind = str(poi.get("type") or "poi")
         name = str(poi.get("name") or "Unknown")
-        poi_id = str(poi.get("id") or f"hex:{q},{r}:{kind}")
+        poi_id = first_time_poi_resolution_key(poi, q=q, r=r, mode="explore")
         self._mark_rumors_seen_for_poi(poi_id)
         note = str(poi.get("notes") or "")
         entry = {
@@ -6328,7 +6357,7 @@ class Game:
         if not isinstance(poi, dict):
             return False
 
-        poi_id = str(poi.get("id") or f"hex:{int(q)},{int(r)}:{str(poi.get('type') or 'poi')}")
+        poi_id = first_time_poi_resolution_key(poi, q=int(q), r=int(r), mode="explore")
         poi_kind = str(poi.get("type") or "poi")
 
         for e in (self._journal_rumors() or []):
@@ -6543,7 +6572,7 @@ class Game:
             "hint": full_hint,
             "locator": locator,
             "cost": cost,
-            "poi_id": str(poi.get("id") or f"hex:{q},{r}:{str(poi.get('type') or 'poi')}"),
+            "poi_id": first_time_poi_resolution_key(poi, q=int(q), r=int(r), mode="explore"),
             "source": "town_rumor",
             "seen": bool(poi.get("discovered", False)),
         }
@@ -6719,7 +6748,8 @@ class Game:
         encounter_mod can be used by travel modes (cautious/forced) to slightly shift encounter chance.
         """
         # Moderate: base 1-in-6 per watch, +1 at night.
-        base = 1 + (1 if self._watch_name() == "Night" else 0)
+        ctx = self.resolve_travel_context(hx)
+        base = 1 + (1 if str(ctx.get("watch") or "") == "Night" else 0)
 
         # Heat / contested territory increases patrol intensity.
         heat = int(hx.get("heat", 0) or 0)
@@ -7770,7 +7800,8 @@ class Game:
     def _wilderness_hud_lines(self) -> list[str]:
         q, r = tuple(getattr(self, "party_hex", (0, 0)))
         hx = self._ensure_current_hex()
-        terrain = str((hx or {}).get("terrain", "clear"))
+        ctx = self.resolve_travel_context(hx)
+        terrain = str(ctx.get("terrain") or "clear")
         heat = int((hx or {}).get("heat", 0) or 0)
         dist = int(hex_distance((0, 0), (q, r)))
         anc = self._get_forward_anchor()
@@ -7781,7 +7812,7 @@ class Game:
             if anc.get("expires_day") is not None:
                 anchor_txt += f" until day {int(anc.get('expires_day', 0) or 0)}"
         return [
-            f"Day {int(getattr(self, 'campaign_day', 1) or 1)} — {self._watch_name()} | Hex ({q},{r}) | {terrain.title()} | Heat {heat} | Dist {dist} | Travel {str(getattr(self, 'wilderness_travel_mode', 'normal')).title()}",
+            f"Day {int(getattr(self, 'campaign_day', 1) or 1)} — {str(ctx.get('watch') or self._watch_name())} | Hex ({q},{r}) | {terrain.title()} | Heat {heat} | Dist {dist} | Travel {str(ctx.get('pace') or getattr(self, 'wilderness_travel_mode', 'normal')).title()}",
             self._party_hud_summary(),
             f"Supplies: {int(getattr(self, 'gold', 0) or 0)} gp | Rations {int(getattr(self, 'rations', 0) or 0)} | Torches {int(getattr(self, 'torches', 0) or 0)}",
             self._light_hud_summary(),
@@ -14458,7 +14489,7 @@ class Game:
         ptype = str(d.get("target_poi_type") or "")
         if ptype and str(poi.get("type") or "") != ptype:
             return d
-        d["target_poi_id"] = str(poi.get("id") or f"hex:{q},{r}:{str(poi.get('type') or 'poi')}")
+        d["target_poi_id"] = first_time_poi_resolution_key(poi, q=q, r=r, mode="explore")
         return d
 
     def _link_rumor_to_contract(self, c: dict[str, Any]) -> None:

--- a/sww/wilderness.py
+++ b/sww/wilderness.py
@@ -4,6 +4,26 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 
+def first_time_poi_resolution_key(poi: dict[str, Any], *, q: int | None = None, r: int | None = None, mode: str = "explore") -> str:
+    """Return a stable first-time gate key for POI interactions.
+
+    Prefer persisted POI ids. Fall back to deterministic structural identity only.
+    """
+    p = poi if isinstance(poi, dict) else {}
+    pid = str(p.get("id") or "").strip()
+    if pid:
+        return pid
+
+    ptype = str(p.get("type") or "poi").strip() or "poi"
+    if q is not None and r is not None:
+        return f"hex:{int(q)},{int(r)}:{ptype}"
+
+    seed = p.get("seed")
+    if seed is not None:
+        return f"seed:{ptype}:{int(seed)}"
+    return f"{ptype}:unknown"
+
+
 # Axial coordinates (q, r)
 # Directions are ordered to be stable for UI and random choices.
 DIRECTIONS: Dict[str, Tuple[int, int]] = {

--- a/tests/test_wilderness_coherence_helpers.py
+++ b/tests/test_wilderness_coherence_helpers.py
@@ -1,0 +1,77 @@
+from sww.game import Game
+from sww.ui_headless import HeadlessUI
+from sww.travel_state import DUNGEON_ENTRANCE_HEX
+from sww.save_load import game_to_dict, apply_game_dict
+from sww.wilderness import first_time_poi_resolution_key
+
+
+def _new_game(seed: int = 17000) -> Game:
+    return Game(HeadlessUI(), dice_seed=seed, wilderness_seed=seed + 1)
+
+
+def test_resolve_travel_context_normalizes_current_wilderness_state():
+    g = _new_game()
+    g.wilderness_travel_mode = "cautious"
+    g.day_watch = 5
+    g.rations = 0
+    hx = g._ensure_current_hex()
+    hx["terrain"] = "road"
+    g.world_hexes[f"{g.party_hex[0]},{g.party_hex[1]}"] = hx
+
+    ctx = g.resolve_travel_context(hx)
+
+    assert ctx["terrain"] == "road"
+    assert ctx["pace"] == "cautious"
+    assert ctx["watch"] == "Night"
+    assert ctx["on_road"] is True
+    assert ctx["low_supplies"] is True
+    assert isinstance(ctx["encounter_mod"], int)
+
+
+def test_resolve_travel_context_used_for_travel_encounter_mod():
+    g = _new_game(seed=17100)
+    seen = {"mod": None}
+
+    g.resolve_travel_context = lambda hx=None: {
+        "terrain": "clear",
+        "pace": "normal",
+        "watch": "Morning",
+        "on_road": False,
+        "party_ready": True,
+        "low_supplies": False,
+        "encounter_mod": 2,
+        "discovery_mod": 0,
+    }
+    g._wilderness_encounter_check = lambda hx, encounter_mod=0: seen.__setitem__("mod", encounter_mod)
+
+    assert g._cmd_travel_to_hex(*DUNGEON_ENTRANCE_HEX).ok
+    assert seen["mod"] == 2
+
+
+def test_first_time_poi_resolution_key_is_stable_across_paths():
+    poi = {"id": "poi:canonical:dungeon_entrance", "type": "dungeon_entrance", "name": "Dungeon Entrance"}
+    assert first_time_poi_resolution_key(poi, q=1, r=0, mode="explore") == first_time_poi_resolution_key(
+        poi, q=4, r=-3, mode="explore"
+    )
+
+
+def test_poi_first_time_reward_or_event_does_not_duplicate():
+    g = _new_game(seed=17200)
+    g._wilderness_encounter_check = lambda hx, encounter_mod=0: None
+    g._handle_current_hex_poi = lambda: None
+
+    assert g._cmd_travel_to_hex(*DUNGEON_ENTRANCE_HEX).ok
+    assert g._cmd_investigate_current_location().ok
+    assert g._cmd_investigate_current_location().ok
+
+    explored = [e for e in (g.event_history or []) if str(e.get("type") or "") == "poi.explored"]
+    assert len(explored) == 1
+
+    data = game_to_dict(g)
+    g2 = _new_game(seed=17201)
+    apply_game_dict(g2, data)
+    g2._handle_current_hex_poi = lambda: None
+    assert g2._cmd_investigate_current_location().ok
+
+    explored2 = [e for e in (g2.event_history or []) if str(e.get("type") or "") == "poi.explored"]
+    assert len(explored2) == 1


### PR DESCRIPTION
### Motivation
- Prevent subtle drift in how travel facts are derived by providing one small, read-only travel context used by encounters, discovery, HUD, and rumor logic.
- Prevent duplicate first-time POI rewards/events by providing a single canonical first-time resolution key for POIs across discovery, rumors, contracts, and encounter paths.

### Description
- Add `first_time_poi_resolution_key()` in `sww/wilderness.py` that prefers a persisted POI `id` and falls back to deterministic structural keys (hex coords, seed, or type) for stable first-time gating.
- Add `Game.resolve_travel_context()` in `sww/game.py` as a tiny read-only normalizer producing `{terrain, pace, watch, on_road, party_ready, low_supplies, encounter_mod, discovery_mod}` and keep it deterministic and side-effect free.
- Wire travel flows and encounter/hud logic to use `resolve_travel_context()` instead of ad-hoc derivation, and route POI identity usage through `first_time_poi_resolution_key()` in exploration, discovery, rumor-surfacing, and contract linking paths.
- Preserve `explored`/`rumored` state when reconciling canonical/secondary POIs and add a focused test file `tests/test_wilderness_coherence_helpers.py` exercising the helpers and non-duplication invariants.

### Testing
- Added targeted tests and ran: `PYTHONPATH=. pytest -q tests/test_wilderness_coherence_helpers.py tests/test_wilderness_poi_discovery.py tests/test_wilderness_rumor_surface.py tests/test_wilderness_encounter_scheduler.py` which completed successfully with all tests passing (16 passed).
- Also ran the helper-only suite `PYTHONPATH=. pytest -q tests/test_wilderness_coherence_helpers.py` which passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1822d325c83289a93f0f2070165cb)