### PR TITLE
Add incremental magic item runtime layer

### DIFF
--- a/docs/magic_item_runtime_layer_note.md
+++ b/docs/magic_item_runtime_layer_note.md
@@ -1,0 +1,49 @@
+# Magic item runtime layer (incremental)
+
+This project now supports a **first safe runtime layer** for magic items through the same item-template and item-instance path used by mundane gear.
+
+## Why narrow-by-design
+
+The implementation intentionally avoids a universal "do everything" effect engine. Instead, templates carry small JSON-friendly effect payloads and runtime helpers expose those payloads for systems that opt in.
+
+That keeps this phase:
+- save-safe,
+- readable,
+- compatible with existing mundane and legacy inventory/equipment flows.
+
+## Template fields supported
+
+`ItemTemplate` now supports:
+- `magic: bool`
+- `cursed: bool`
+- `identified_name: str | None`
+- `unidentified_name: str | None`
+- `wear_category: str | None`
+- `effects: list[dict]`
+- `charges: int | None`
+- `metadata: dict` (rules payload)
+
+Instances inherit these in `ItemInstance.metadata` during construction so old call sites can read a stable payload without deep template coupling.
+
+## Supported runtime effect types (phase 1)
+
+- `attack_bonus`
+- `damage_bonus`
+- `ac_bonus`
+- `save_bonus`
+- `movement_bonus`
+- `granted_tag`
+- `sticky_equip`
+- `light_source`
+- `consumable_heal`
+- `spell_cast`
+
+Compatibility aliases currently normalize:
+- `heal` -> `consumable_heal`
+- `cast_spell` -> `spell_cast`
+
+## Unsupported placeholders
+
+Unsupported effect types are intentionally not executed here. They are surfaced explicitly via helper detection (`item_unsupported_effect_types`) so downstream systems can fail fast or ignore by policy.
+
+This is deliberate: effect *transport* and effect *execution* are decoupled until combat/spell integrations are implemented in focused slices.

--- a/sww/item_templates.py
+++ b/sww/item_templates.py
@@ -31,7 +31,34 @@ class ItemTemplate:
     value_gp: float = 0.0
     tags: list[str] = field(default_factory=list)
     equip_slot_hint: str | None = None
+    magic: bool = False
+    cursed: bool = False
+    identified_name: str | None = None
+    unidentified_name: str | None = None
+    wear_category: str | None = None
+    effects: list[dict[str, Any]] = field(default_factory=list)
+    charges: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
     rules: dict[str, Any] = field(default_factory=dict)
+
+
+SUPPORTED_ITEM_EFFECT_TYPES: set[str] = {
+    "attack_bonus",
+    "damage_bonus",
+    "ac_bonus",
+    "save_bonus",
+    "movement_bonus",
+    "granted_tag",
+    "sticky_equip",
+    "light_source",
+    "consumable_heal",
+    "spell_cast",
+}
+
+_EFFECT_TYPE_ALIASES: dict[str, str] = {
+    "heal": "consumable_heal",
+    "cast_spell": "spell_cast",
+}
 
 
 _INSTANCE_SEQ = count(1)
@@ -56,6 +83,21 @@ def _slot_hint_for_category(category: str) -> str | None:
     if c == "wand":
         return "main_hand"
     return None
+
+
+def _normalized_effects(rows: list[Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for row in list(rows or []):
+        if not isinstance(row, dict):
+            continue
+        effect_type = str(row.get("type") or row.get("effect_type") or row.get("effect") or "").strip().lower()
+        if not effect_type:
+            continue
+        mapped = _EFFECT_TYPE_ALIASES.get(effect_type, effect_type)
+        payload = dict(row)
+        payload["type"] = mapped
+        out.append(payload)
+    return out
 
 
 class ItemTemplateCatalog:
@@ -178,8 +220,16 @@ def _add_bespoke_templates(catalog: ItemTemplateCatalog) -> None:
                 value_gp=float(row.get("value_gp", 0.0) or 0.0),
                 tags=[str(t) for t in (row.get("tags") or [])],
                 equip_slot_hint=_slot_hint_for_category(kind),
+                magic=True,
+                cursed=bool(row.get("cursed", False)),
+                identified_name=row.get("identified_name"),
+                unidentified_name=row.get("unidentified_name"),
+                wear_category=row.get("wear_category"),
+                effects=_normalized_effects(list(row.get("effects") or [])),
+                charges=(int(row["charges"]) if row.get("charges") is not None else None),
+                metadata=dict(row.get("metadata") or {}),
                 rules={
-                    "effects": list(row.get("effects") or []),
+                    "effects": _normalized_effects(list(row.get("effects") or [])),
                     "payload": dict(row.get("payload") or {}),
                 },
             )
@@ -264,6 +314,66 @@ def template_weight_lb(template: ItemTemplate) -> float:
     return max(0.0, float(template.weight_lb or 0.0))
 
 
+def _coerce_template(template_or_instance: ItemTemplate | ItemInstance | None) -> ItemTemplate | None:
+    if isinstance(template_or_instance, ItemTemplate):
+        return template_or_instance
+    if isinstance(template_or_instance, ItemInstance):
+        try:
+            return get_item_template(template_or_instance.template_id)
+        except KeyError:
+            return None
+    return None
+
+
+def item_is_magic(template_or_instance: ItemTemplate | ItemInstance | None) -> bool:
+    t = _coerce_template(template_or_instance)
+    if t is not None:
+        return bool(t.magic)
+    if isinstance(template_or_instance, ItemInstance):
+        return "magic" in {str(x).lower() for x in list((template_or_instance.metadata or {}).get("tags") or [])}
+    return False
+
+
+def item_is_cursed(template_or_instance: ItemTemplate | ItemInstance | None) -> bool:
+    t = _coerce_template(template_or_instance)
+    if t is not None:
+        return bool(t.cursed)
+    if isinstance(template_or_instance, ItemInstance):
+        return bool((template_or_instance.metadata or {}).get("cursed", False))
+    return False
+
+
+def item_effects(template_or_instance: ItemTemplate | ItemInstance | None) -> list[dict[str, Any]]:
+    if isinstance(template_or_instance, ItemInstance):
+        from_metadata = _normalized_effects(list((template_or_instance.metadata or {}).get("effects") or []))
+        if from_metadata:
+            return from_metadata
+    t = _coerce_template(template_or_instance)
+    if t is not None:
+        return [dict(e) for e in list(t.effects or [])]
+    return []
+
+
+def item_unsupported_effect_types(template_or_instance: ItemTemplate | ItemInstance | None) -> list[str]:
+    types = [str(e.get("type") or "") for e in item_effects(template_or_instance)]
+    return sorted({t for t in types if t and t not in SUPPORTED_ITEM_EFFECT_TYPES})
+
+
+def item_display_name(
+    instance: ItemInstance,
+    template: ItemTemplate | None = None,
+    *,
+    identified: bool | None = None,
+) -> str:
+    t = template or _coerce_template(instance)
+    is_identified = bool(instance.identified if identified is None else identified)
+    if t is None:
+        return str(instance.name or "Unknown item")
+    if is_identified:
+        return str(t.identified_name or t.name)
+    return str(t.unidentified_name or t.wear_category or "Unidentified magic item")
+
+
 def build_item_instance(
     template_id: str,
     *,
@@ -281,6 +391,15 @@ def build_item_instance(
     md.setdefault("weight_lb", template_weight_lb(t))
     md.setdefault("value_gp", float(t.value_gp or 0.0))
     md.setdefault("equip_slot_hint", t.equip_slot_hint)
+    md.setdefault("magic", bool(t.magic))
+    md.setdefault("cursed", bool(t.cursed))
+    md.setdefault("identified_name", t.identified_name)
+    md.setdefault("unidentified_name", t.unidentified_name)
+    md.setdefault("wear_category", t.wear_category)
+    md.setdefault("effects", [dict(e) for e in list(t.effects or [])])
+    md.setdefault("charges", t.charges)
+    md.setdefault("template_metadata", dict(t.metadata or {}))
+    md.setdefault("unsupported_effect_types", item_unsupported_effect_types(t))
     md.setdefault("rules", dict(t.rules or {}))
 
     return ItemInstance(

--- a/tests/test_item_templates.py
+++ b/tests/test_item_templates.py
@@ -1,4 +1,14 @@
-from sww.item_templates import build_item_instance, get_item_template, template_weight_lb
+from sww.item_templates import (
+    SUPPORTED_ITEM_EFFECT_TYPES,
+    build_item_instance,
+    get_item_template,
+    item_display_name,
+    item_effects,
+    item_is_cursed,
+    item_is_magic,
+    item_unsupported_effect_types,
+    template_weight_lb,
+)
 
 
 def test_weapon_template_loads_from_extracted_data():
@@ -21,3 +31,33 @@ def test_build_item_instance_from_template():
     assert inst.quantity == 2
     assert inst.name == "Sword, long"
     assert "weight_lb" in inst.metadata
+
+
+def test_magic_template_fields_and_helpers_roundtrip():
+    t = get_item_template("potion.potion_healing")
+    assert item_is_magic(t)
+    assert not item_is_cursed(t)
+    assert item_effects(t)
+    assert item_effects(t)[0]["type"] == "consumable_heal"
+    assert not item_unsupported_effect_types(t)
+
+
+def test_item_instance_metadata_contains_magic_runtime_payload():
+    inst = build_item_instance("potion.potion_healing", identified=False)
+    assert item_is_magic(inst)
+    assert inst.metadata.get("effects")
+    assert inst.metadata.get("unsupported_effect_types") == []
+    assert item_display_name(inst) == "Unidentified magic item"
+
+
+def test_unsupported_effect_type_detection_is_explicit():
+    inst = build_item_instance(
+        "gear.lantern_bullseye",
+        metadata={"effects": [{"type": "future_placeholder"}]},
+    )
+    assert item_unsupported_effect_types(inst) == ["future_placeholder"]
+
+
+def test_supported_effect_catalog_includes_expected_runtime_types():
+    assert "attack_bonus" in SUPPORTED_ITEM_EFFECT_TYPES
+    assert "spell_cast" in SUPPORTED_ITEM_EFFECT_TYPES


### PR DESCRIPTION
### Motivation
- Provide a safe, incremental runtime layer for magic items that is data-driven and JSON-friendly while remaining compatible with existing mundane item and legacy inventory flows.
- Keep effect handling narrow and explicit to avoid introducing a universal rules engine and to make future execution slices focused and auditable.

### Description
- Extend `ItemTemplate` with explicit magic-related fields: `magic`, `cursed`, `identified_name`, `unidentified_name`, `wear_category`, `effects`, `charges`, and `metadata` so templates can carry small, stable payloads.
- Add effect normalization and aliases plus a bounded supported-effect catalog (`SUPPORTED_ITEM_EFFECT_TYPES`) to normalize legacy keys (`heal`→`consumable_heal`, `cast_spell`→`spell_cast`) and make unsupported effects easy to detect.
- Add helper APIs: `item_is_magic(...)`, `item_is_cursed(...)`, `item_effects(...)`, `item_unsupported_effect_types(...)`, and `item_display_name(...)`, and ensure `build_item_instance(...)` copies magic/template payload into `ItemInstance.metadata` for backward compatibility.
- Add a concise docs note and focused tests to document supported payloads, surface unsupported placeholders, and verify helper behavior.

### Testing
- `python -m py_compile sww/item_templates.py tests/test_item_templates.py` succeeded (byte-compile ok).
- `pytest -q tests/test_item_templates.py` initially failed in an environment missing `sww` on `PYTHONPATH` (ModuleNotFoundError), as expected for that runner configuration.
- `PYTHONPATH=. pytest -q tests/test_item_templates.py` passed: 7 passed.

Files changed: `sww/item_templates.py`, `tests/test_item_templates.py`, and `docs/magic_item_runtime_layer_note.md`.

Supported effect types added: `attack_bonus`, `damage_bonus`, `ac_bonus`, `save_bonus`, `movement_bonus`, `granted_tag`, `sticky_equip`, `light_source`, `consumable_heal`, and `spell_cast`.

Effect/runtime work intentionally deferred: implementing a universal effect executor, broad combat/spell-system rewrites, and automatic execution of unsupported placeholder effect types.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29a0b7470832882d9266a7637ad56)