### PR TITLE
Use loot-pool identity for encounter recap item delta

### DIFF
--- a/sww/game.py
+++ b/sww/game.py
@@ -508,6 +508,21 @@ class Game:
             self._encounter_start_items = items
         except Exception:
             self._encounter_start_items = []
+        # Ownership-first snapshot: encounter item deltas should prefer loot_pool
+        # entry identity over legacy shared `party_items` append/diff assumptions.
+        try:
+            lp = getattr(self, "loot_pool", None)
+            if lp is None or not hasattr(lp, "entries"):
+                raise ValueError("loot_pool_unavailable")
+            self._encounter_start_loot_entry_ids = {
+                str(getattr(e, "entry_id", "") or "")
+                for e in list(getattr(lp, "entries", []) or [])
+                if str(getattr(e, "entry_id", "") or "").strip()
+            }
+            self._encounter_loot_pool_available = True
+        except Exception:
+            self._encounter_start_loot_entry_ids = set()
+            self._encounter_loot_pool_available = False
         # sum xp across PCs (works even if xp awards happen outside combat)
         try:
             xp_sum = 0
@@ -557,6 +572,8 @@ class Game:
 
         start_gold = int(getattr(self, "_encounter_start_gold", 0) or 0)
         start_items = list(getattr(self, "_encounter_start_items", []) or [])
+        start_loot_entry_ids = set(getattr(self, "_encounter_start_loot_entry_ids", set()) or set())
+        loot_pool_available = bool(getattr(self, "_encounter_loot_pool_available", False))
         start_xp_sum = int(getattr(self, "_encounter_start_xp_sum", 0) or 0)
 
         end_gold = int(getattr(self, "gold", 0) or 0)
@@ -576,17 +593,26 @@ class Game:
             end_xp_sum = start_xp_sum
 
         gp_delta = int(end_gold - start_gold)
-        # new items by identity (best-effort; items may be dicts/strings)
-        new_items = []
-        try:
-            # Use repr string for stable diff without depending on hashability.
-            start_set = set([repr(x) for x in start_items])
-            for it in end_items:
-                r = repr(it)
-                if r not in start_set:
-                    new_items.append(it)
-        except Exception:
-            new_items = []
+        # Ownership-first item delta by stable loot entry identity.
+        # Legacy `party_items` diffing remains an explicit compatibility fallback only
+        # when loot_pool state is unavailable.
+        new_items: list[str] = []
+        if loot_pool_available:
+            try:
+                new_items = self._combat_loot_item_names_delta(start_loot_entry_ids)
+            except Exception:
+                new_items = []
+        else:
+            try:
+                # Compatibility fallback for mixed-mode saves/code paths.
+                # Use repr string for stable diff without depending on hashability.
+                start_set = set([repr(x) for x in start_items])
+                for it in end_items:
+                    r = repr(it)
+                    if r not in start_set:
+                        new_items.append(str(getattr(it, "get", lambda k, d=None: None)("name") or it))
+            except Exception:
+                new_items = []
         xp_delta = int(end_xp_sum - start_xp_sum)
 
         # Print recap only if something happened.
@@ -612,13 +638,13 @@ class Game:
         # Extra rewards beyond what combat summary already reported.
         extra_gp = int(gp_delta) - int(combat_gp)
         extra_xp = int(xp_delta) - int(combat_xp)
-        extra_items = []
+        extra_items: list[str] = []
         try:
             for it in (new_items or []):
                 if str(it) not in combat_item_names:
-                    extra_items.append(it)
+                    extra_items.append(str(it))
         except Exception:
-            extra_items = list(new_items or [])
+            extra_items = [str(x) for x in list(new_items or [])]
 
         if combat_summary_evt is not None or gp_delta or xp_delta or new_items:
             try:
@@ -680,7 +706,7 @@ class Game:
                 room_type=getattr(self, "_encounter_room_type", None),
                 gp_delta=int(gp_delta),
                 xp_delta=int(xp_delta),
-                items_gained=[repr(x) for x in new_items],
+                items_gained=[str(x) for x in (new_items or [])],
                 loot_events=list(getattr(self, "_encounter_loot_events", []) or []),
             )
         except Exception:

--- a/tests/test_loot_pool.py
+++ b/tests/test_loot_pool.py
@@ -336,3 +336,71 @@ def test_combat_loot_delta_prefers_loot_pool_entries_over_legacy_party_items():
 
     assert "New Gem" in names
     assert "Old Gem" not in names
+
+
+def _last_encounter_recap_event(game: Game):
+    events = [ev for ev in list(getattr(game.events, "events", []) or []) if getattr(ev, "name", "") == "encounter_recap"]
+    assert events
+    return events[-1]
+
+
+def test_encounter_end_capture_prefers_loot_pool_delta_when_party_items_stale():
+    g = Game(HeadlessUI(), dice_seed=30260, wilderness_seed=30261)
+    _gp, added = add_generated_treasure_to_pool(g.loot_pool, items=[{"name": "Old Gem", "kind": "treasure", "gp_value": 10}])
+    assert len(added) == 1
+
+    g._encounter_begin_capture(context="test")
+    add_generated_treasure_to_pool(g.loot_pool, items=[{"name": "New Gem", "kind": "treasure", "gp_value": 20}])
+    # Legacy shared list is intentionally stale/empty; recap should still use loot_pool identity delta.
+    g.party_items = []
+    g._encounter_end_capture()
+
+    recap = _last_encounter_recap_event(g)
+    items = list((recap.data or {}).get("items_gained", []) or [])
+    assert "New Gem" in items
+    assert "Old Gem" not in items
+
+
+def test_encounter_end_capture_handles_duplicate_unidentified_labels_by_entry_identity():
+    g = Game(HeadlessUI(), dice_seed=30270, wilderness_seed=30271)
+
+    g._encounter_begin_capture(context="test")
+    add_generated_treasure_to_pool(
+        g.loot_pool,
+        items=[
+            {"name": "Mysterious Potion", "true_name": "Potion of Healing", "kind": "potion"},
+            {"name": "Mysterious Potion", "true_name": "Potion of Heroism", "kind": "potion"},
+        ],
+        identify_magic=False,
+    )
+    g._encounter_end_capture()
+
+    recap = _last_encounter_recap_event(g)
+    items = list((recap.data or {}).get("items_gained", []) or [])
+    assert len(items) == 2
+    assert items.count("Mysterious Potion") == 2
+
+
+def test_encounter_end_capture_legacy_fallback_only_when_loot_pool_unavailable():
+    # Explicit fallback path: no loot_pool state available.
+    g_fallback = Game(HeadlessUI(), dice_seed=30280, wilderness_seed=30281)
+    g_fallback.loot_pool = None
+    g_fallback.party_items = [{"name": "Old Relic", "kind": "treasure"}]
+
+    g_fallback._encounter_begin_capture(context="test")
+    g_fallback.party_items.append({"name": "New Relic", "kind": "treasure"})
+    g_fallback._encounter_end_capture()
+
+    fallback_recap = _last_encounter_recap_event(g_fallback)
+    fallback_items = list((fallback_recap.data or {}).get("items_gained", []) or [])
+    assert "New Relic" in fallback_items
+
+    # When loot_pool is available, do not silently prefer legacy party_items diffs.
+    g_primary = Game(HeadlessUI(), dice_seed=30282, wilderness_seed=30283)
+    g_primary._encounter_begin_capture(context="test")
+    g_primary.party_items.append({"name": "Legacy Ghost", "kind": "treasure"})
+    g_primary._encounter_end_capture()
+
+    primary_recap = _last_encounter_recap_event(g_primary)
+    primary_items = list((primary_recap.data or {}).get("items_gained", []) or [])
+    assert primary_items == []


### PR DESCRIPTION
### Motivation
- Ensure encounter recap reports item gains using ownership-first loot-pool identity (stable `entry_id`) rather than fragile `party_items` append/diff assumptions. 
- Keep the change narrowly scoped to encounter-end capture/delta/reporting and provide an explicit legacy fallback only when loot-pool state is unavailable.

### Description
- Snapshot loot-pool entry IDs at encounter start by adding `_encounter_start_loot_entry_ids` and an availability flag in `Game._encounter_begin_capture`.
- Compute encounter `new_items` in `Game._encounter_end_capture` via the ownership-first helper `Game._combat_loot_item_names_delta(start_ids)` when the loot pool is available, and fall back to legacy `party_items` diffing only when loot-pool state is unavailable (compatibility bridge with clear comments).
- Normalize emitted recap payload `items_gained` to string labels while keeping identity-based delta logic separate from display formatting, and preserve correct counts for duplicate/unidentified labels by basing the delta on entry identity.
- Files changed: `sww/game.py`, `tests/test_loot_pool.py`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_loot_pool.py -k "encounter_end_capture or combat_loot_delta_prefers"` which passed (targeted subset: 4 passed, 19 deselected). Note: a collection attempt without `PYTHONPATH=.` raised `ModuleNotFoundError` due to import path, fixed by running tests with `PYTHONPATH=.`.
- Ran `PYTHONPATH=. pytest -q tests/test_loot_pool.py` which passed (23 passed). The added tests verify that the encounter recap prefers loot-pool identity deltas when `party_items` is stale, handles duplicate/unidentified labels correctly by entry identity, and exercises the legacy fallback only when the loot-pool is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c3d9d6608328aed3b52b1dd269a1)