### PR TITLE
Add dungeon light pressure: warnings, darkness consequences, and action blocking

### DIFF
--- a/sww/game.py
+++ b/sww/game.py
@@ -119,6 +119,7 @@ class Game:
 
     # Exploration pacing
     TORCH_TURNS = 6  # 1 torch = 6 dungeon turns (10-minute turns)
+    LOW_LIGHT_WARNING_TURNS = 2
 
     # Wilderness pacing (B/X-ish)
     # 6-mile hex; we model travel in 4-hour watches (6 watches per day)
@@ -2908,6 +2909,10 @@ class Game:
         return CommandResult(status="ok")
 
     def _cmd_dungeon_listen(self) -> CommandResult:
+        blocked = self._dungeon_precision_action_requires_light(action="listen at doors")
+        if blocked is not None:
+            return blocked
+
         """Listen at a closed door.
 
         This is a *turn action* in the dungeon loop (the loop already consumes one turn
@@ -3069,6 +3074,9 @@ class Game:
         return 6, lvl
 
     def _cmd_dungeon_search_secret(self) -> CommandResult:
+        blocked = self._dungeon_precision_action_requires_light(action="search for secret doors")
+        if blocked is not None:
+            return blocked
         room = self._ensure_room(self.current_room_id)
 
         rid = int(self.current_room_id)
@@ -3119,6 +3127,9 @@ class Game:
 
     
     def _cmd_dungeon_search_traps(self) -> CommandResult:
+        blocked = self._dungeon_precision_action_requires_light(action="search for traps")
+        if blocked is not None:
+            return blocked
         room = self._ensure_room(self.current_room_id)
 
         # Only meaningful if the room has a trap spec.
@@ -3194,6 +3205,9 @@ class Game:
         return CommandResult(status="info")
 
     def _cmd_dungeon_sneak(self) -> CommandResult:
+        blocked = self._dungeon_precision_action_requires_light(action="sneak safely")
+        if blocked is not None:
+            return blocked
         # Use the best party member with both Move Silently and Hide in Shadows skills.
         best_pc = None
         best_ms = 0
@@ -10154,6 +10168,8 @@ class Game:
         self.torch_turns_left = self.TORCH_TURNS
         self.light_on = True
         self.ui.log("You light a torch.")
+        if int(self.torches) <= 1:
+            self.ui.log(f"Warning: only {int(self.torches)} spare torch{'es' if int(self.torches) != 1 else ''} left.")
 
     def spend_dungeon_time(self, turns: int, *, reason: str) -> None:
         """Spend dungeon time in 10-minute turns.
@@ -10217,16 +10233,24 @@ class Game:
             if self.torch_turns_left <= 0:
                 self.torch_turns_left = 0
                 self.ui.log("Your torch sputters out.")
+            elif int(self.torch_turns_left) <= int(self.LOW_LIGHT_WARNING_TURNS):
+                self.ui.log(f"Warning: torchlight is running low ({int(self.torch_turns_left)} turn{'s' if int(self.torch_turns_left) != 1 else ''} left).")
 
         if int(getattr(self, "magical_light_turns", 0) or 0) > 0:
             self.magical_light_turns -= 1
             if self.magical_light_turns <= 0:
                 self.magical_light_turns = 0
                 self.ui.log("The magical light fades.")
+            elif int(self.magical_light_turns) <= int(self.LOW_LIGHT_WARNING_TURNS):
+                self.ui.log(f"Warning: magical light is running low ({int(self.magical_light_turns)} turn{'s' if int(self.magical_light_turns) != 1 else ''} left).")
 
         self.light_on = bool(self.torch_turns_left > 0 or self.magical_light_turns > 0)
         if was_lit and not self.light_on:
             self.ui.log("Darkness!")
+        if not self.light_on:
+            self.noise_level = min(5, int(getattr(self, "noise_level", 0) or 0) + 1)
+            self.ui.log("You fumble in darkness; noise and risk rise.")
+            self.emit("dungeon_darkness_pressure", dungeon_turn=int(self.dungeon_turn), noise_level=int(self.noise_level))
         # Noise decay (deterministic): noise points fall by 1 per turn.
         if self.noise_level > 0:
             self.noise_level -= 1
@@ -10298,7 +10322,17 @@ class Game:
             pressure = max(pressure, 1)
         if alarm >= 4:
             pressure = min(2, pressure + 1)
+        if not bool(getattr(self, "light_on", False)):
+            pressure = min(2, pressure + 1)
         return pressure
+
+    def _dungeon_precision_action_requires_light(self, *, action: str) -> CommandResult | None:
+        if bool(getattr(self, "light_on", False)):
+            return None
+        msg = f"Too dark to {str(action)}. Light a torch or cast Light first."
+        self.ui.log(msg)
+        self.emit("dungeon_action_blocked_darkness", action=str(action), room_id=int(getattr(self, "current_room_id", 0) or 0))
+        return CommandResult(status="error", messages=("darkness",))
 
     def _check_wandering_monster(self) -> bool:
         """Return True if a wandering monster is triggered this turn.

--- a/sww/game.py
+++ b/sww/game.py
@@ -8707,6 +8707,34 @@ class Game:
             self._active_objective_hud(),
         ]
 
+    def _dungeon_pressure_summary(self) -> str:
+        """Compact, deterministic dungeon pressure readout for exploration UI."""
+        torch_turns = int(getattr(self, "torch_turns_left", 0) or 0)
+        magic_turns = int(getattr(self, "magical_light_turns", 0) or 0)
+        reserve_torches = int(getattr(self, "torches", 0) or 0)
+        noise = int(getattr(self, "noise_level", 0) or 0)
+        lvl = int(getattr(self, "dungeon_level", 1) or 1)
+        alarm = int((getattr(self, 'dungeon_alarm_by_level', {}) or {}).get(lvl, 0) or 0)
+
+        if torch_turns > 0 and magic_turns > 0:
+            light_txt = f"Light torch {torch_turns}t + magic {magic_turns}t"
+        elif torch_turns > 0:
+            light_txt = f"Light torch {torch_turns}t"
+        elif magic_turns > 0:
+            light_txt = f"Light magic {magic_turns}t"
+        else:
+            light_txt = "Light DARK"
+
+        risk_mod = int(self._wandering_noise_mod())
+        base = int(getattr(self, "wandering_chance", 1) or 1)
+        chance_cap = 5 if alarm >= 4 else 4
+        wander_in_6 = min(chance_cap, max(1, base + risk_mod))
+
+        return (
+            f"Pressure: {light_txt} | Spare torches {reserve_torches} | Noise {noise}/5"
+            f" | Alarm {alarm}/5 | Wander {wander_in_6}/6 (mod +{risk_mod})"
+        )
+
     def _dungeon_hud_lines(self) -> list[str]:
         lvl = int(getattr(self, "dungeon_level", 1) or 1)
         rid = int(getattr(self, "current_room_id", 0) or 0)
@@ -8717,7 +8745,7 @@ class Game:
             f"Day {int(getattr(self, 'campaign_day', 1) or 1)} — {self._watch_name()} | Dungeon L{lvl} | Room {rid} | {room_kind.title()}",
             self._party_hud_summary(),
             f"Supplies: {int(getattr(self, 'gold', 0) or 0)} gp | Rations {int(getattr(self, 'rations', 0) or 0)} | Torches {int(getattr(self, 'torches', 0) or 0)}",
-            self._light_hud_summary() + f" | Noise {int(getattr(self, 'noise_level', 0) or 0)}/5" + f" | Alarm {alarm}/5",
+            self._dungeon_pressure_summary(),
             self._active_objective_hud(),
         ]
 
@@ -10043,7 +10071,7 @@ class Game:
                 pass
             lvl = int(getattr(self, "dungeon_level", 1) or 1)
             alarm = int((getattr(self, "dungeon_alarm_by_level", {}) or {}).get(lvl, 0))
-            self.ui.log(f"Turn {self.dungeon_turn} | Torch: {self.torch_turns_left} turns | Noise: {self.noise_level}/5 | Dungeon Level: {lvl}/{int(getattr(self, 'max_dungeon_levels', 1))} | Alarm: {alarm}/5")
+            self.ui.log(f"Turn {self.dungeon_turn} | {self._dungeon_pressure_summary()}")
             self.ui.log(f"Room {self.current_room_id}: {room['type']} | Visited {room.get('visited', 0)}x")
             if room.get("cleared"):
                 self.ui.log("This room seems quiet (cleared).")

--- a/sww/save_load.py
+++ b/sww/save_load.py
@@ -1715,6 +1715,7 @@ def apply_game_dict(game: Any, data: Dict[str, Any]) -> None:
     setattr(game, "dungeon_turn", int(dung.get("dungeon_turn", 0)))
     setattr(game, "torch_turns_left", int(dung.get("torch_turns_left", 0)))
     setattr(game, "magical_light_turns", int(dung.get("magical_light_turns", 0)))
+    setattr(game, "light_on", bool(int(dung.get("torch_turns_left", 0) or 0) > 0 or int(dung.get("magical_light_turns", 0) or 0) > 0))
     setattr(game, "current_room_id", int(dung.get("current_room_id", 0)))
     rooms = dung.get("dungeon_rooms", {}) or {}
     # Normalize JSON object keys back to ints when possible.

--- a/tests/test_dungeon_light_pressure.py
+++ b/tests/test_dungeon_light_pressure.py
@@ -1,0 +1,69 @@
+from sww.game import Game
+from sww.ui_headless import HeadlessUI
+from sww.save_load import game_to_dict, apply_game_dict
+
+
+def _new_game(seed: int = 12000) -> Game:
+    g = Game(HeadlessUI(), dice_seed=seed, wilderness_seed=seed + 1)
+    g._check_wandering_monster = lambda: False
+    return g
+
+
+def test_dungeon_time_spend_consumes_light_and_warns_low_torch():
+    g = _new_game()
+    g.light_on = True
+    g.torch_turns_left = 3
+    g.magical_light_turns = 0
+
+    g.spend_dungeon_time(1, reason="test")
+
+    assert g.dungeon_turn == 1
+    assert g.torch_turns_left == 2
+    assert any("torchlight is running low (2 turns left)" in ln for ln in g.ui.lines)
+
+
+def test_zero_light_adds_darkness_pressure_and_logs_consequence():
+    g = _new_game(seed=12010)
+    g.light_on = False
+    g.torch_turns_left = 0
+    g.magical_light_turns = 0
+    g.noise_level = 0
+
+    g.spend_dungeon_time(1, reason="test_dark")
+
+    assert g.dungeon_turn == 1
+    assert g.noise_level == 0  # +1 darkness pressure, then deterministic -1 decay in same turn
+    assert any("fumble in darkness" in ln for ln in g.ui.lines)
+    assert any((e.name == "dungeon_darkness_pressure") for e in g.events.events)
+
+
+def test_darkness_blocks_precision_search_actions():
+    g = _new_game(seed=12020)
+    g.current_room_id = 1
+    g.light_on = False
+    g.torch_turns_left = 0
+    g.magical_light_turns = 0
+
+    res = g._cmd_dungeon_search_secret()
+
+    assert res.status == "error"
+    assert any("Too dark to search for secret doors" in ln for ln in g.ui.lines)
+
+
+def test_save_load_preserves_dungeon_light_pressure_state():
+    g = _new_game(seed=12030)
+    g.dungeon_turn = 4
+    g.torches = 1
+    g.torch_turns_left = 2
+    g.magical_light_turns = 0
+    g.light_on = True
+
+    payload = game_to_dict(g)
+
+    g2 = _new_game(seed=12031)
+    apply_game_dict(g2, payload)
+
+    assert g2.dungeon_turn == 4
+    assert g2.torches == 1
+    assert g2.torch_turns_left == 2
+    assert g2.light_on is True

--- a/tests/test_dungeon_light_pressure.py
+++ b/tests/test_dungeon_light_pressure.py
@@ -67,3 +67,56 @@ def test_save_load_preserves_dungeon_light_pressure_state():
     assert g2.torches == 1
     assert g2.torch_turns_left == 2
     assert g2.light_on is True
+
+
+def test_dungeon_pressure_summary_surfaces_lit_state_fields():
+    g = _new_game(seed=12040)
+    g.light_on = True
+    g.torches = 4
+    g.torch_turns_left = 2
+    g.magical_light_turns = 0
+    g.noise_level = 1
+    g.wandering_chance = 1
+    g.dungeon_alarm_by_level[g.dungeon_level] = 0
+
+    line = g._dungeon_pressure_summary()
+
+    assert "Pressure:" in line
+    assert "Light torch 2t" in line
+    assert "Spare torches 4" in line
+    assert "Noise 1/5" in line
+    assert "Wander 1/6" in line
+
+
+def test_dungeon_pressure_summary_surfaces_dark_state_explicitly():
+    g = _new_game(seed=12050)
+    g.light_on = False
+    g.torch_turns_left = 0
+    g.magical_light_turns = 0
+    g.torches = 0
+    g.noise_level = 0
+
+    line = g._dungeon_pressure_summary()
+
+    assert "Light DARK" in line
+    assert "Spare torches 0" in line
+
+
+def test_dungeon_pressure_summary_after_save_load_continuity():
+    g = _new_game(seed=12060)
+    g.dungeon_turn = 4
+    g.torches = 1
+    g.torch_turns_left = 1
+    g.magical_light_turns = 0
+    g.light_on = True
+    g.noise_level = 2
+
+    payload = game_to_dict(g)
+
+    g2 = _new_game(seed=12061)
+    apply_game_dict(g2, payload)
+
+    line = g2._dungeon_pressure_summary()
+    assert "Light torch 1t" in line
+    assert "Spare torches 1" in line
+    assert "Noise 2/5" in line


### PR DESCRIPTION
### Motivation
- Surface clear, deterministic light/time pressure during dungeon exploration so players see costs and risks without a full survival simulation. 
- Reuse existing torch/magical-light and turn-progression fields rather than inventing a parallel supply subsystem. 
- Keep behavior simple and deterministic to preserve replay/save/load continuity and ease of inspection.

### Description
- Introduced a low-light threshold constant `LOW_LIGHT_WARNING_TURNS = 2` and emit readable warnings when torch or magical light approaches that threshold and when spare torches are critically low (in `sww/game.py`).
- On turn tick, when light goes out the system now logs a clear consequence, increments `noise_level`, emits a `dungeon_darkness_pressure` event, and increases wandering-pressure contribution when dark (in `sww/game.py`).
- Blocked precision exploration actions (`listen`, `search secret doors`, `search traps`, `sneak`) when there is no active light using a small helper that returns an explicit error and emits `dungeon_action_blocked_darkness` (in `sww/game.py`).
- Preserve save/load continuity by deriving `light_on` from persisted `torch_turns_left` and `magical_light_turns` during load (in `sww/save_load.py`).
- Added targeted tests that exercise time-based light depletion, low-light warnings, darkness consequences, dark-action blocking, and save/load light continuity (new `tests/test_dungeon_light_pressure.py`).

### Testing
- Ran targeted unit tests: `PYTHONPATH=. pytest -q tests/test_dungeon_light_pressure.py tests/test_loot_pool.py tests/test_wilderness_clock_integration.py` which passed (`41 passed`).
- Ran subsystem self-check: `PYTHONPATH=. python -m sww.selftest` which succeeded.
- Ran broader test runs during validation and observed unrelated pre-existing failures in a small number of full-suite fixtures (these are outside the scope of this change); the pressure-focused tests and relevant integration tests passed.

Files changed: `sww/game.py`, `sww/save_load.py`, `tests/test_dungeon_light_pressure.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41a83ba60832891ee4349df6a123c)