### PR TITLE
Add deterministic reusable trap framework for dungeon exploration

### DIFF
--- a/sww/commands.py
+++ b/sww/commands.py
@@ -210,6 +210,11 @@ class DungeonSearchTraps(Command):
 
 
 @dataclass(frozen=True)
+class DungeonInteractTrap(Command):
+    pass
+
+
+@dataclass(frozen=True)
 class DungeonSneak(Command):
     pass
 

--- a/sww/dungeon_traps.py
+++ b/sww/dungeon_traps.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TrapProfile:
+    kind: str
+    name: str
+    warning_signs: tuple[str, ...]
+    trigger_text: str
+    damage: str
+    alarm: bool = False
+    noise: int = 1
+    extra_turn_cost: int = 0
+    light_loss: int = 0
+
+
+TRAP_PROFILES: dict[str, TrapProfile] = {
+    "pit": TrapProfile(
+        kind="pit",
+        name="Pit Trap",
+        warning_signs=("Loose dust gathers around a seam in the floor.",),
+        trigger_text="The floor drops away into a pit!",
+        damage="1d6",
+        alarm=False,
+        noise=1,
+    ),
+    "dart": TrapProfile(
+        kind="dart",
+        name="Dart Trap",
+        warning_signs=("Tiny holes pepper one wall at waist height.",),
+        trigger_text="Darts hiss out from hidden slits!",
+        damage="1d4",
+        alarm=False,
+        noise=1,
+    ),
+    "gas": TrapProfile(
+        kind="gas",
+        name="Gas Trap",
+        warning_signs=("A faint acrid smell hangs in the stale air.",),
+        trigger_text="A cloud of choking gas floods the chamber!",
+        damage="1d4",
+        alarm=False,
+        noise=0,
+        extra_turn_cost=1,
+        light_loss=1,
+    ),
+}
+
+
+LEGACY_DESC_TO_KIND = {
+    "pit": "pit",
+    "darts": "dart",
+    "dart": "dart",
+    "gas": "gas",
+}
+
+
+def trap_profile(kind: str | None) -> TrapProfile:
+    k = str(kind or "").strip().lower()
+    if not k:
+        k = "pit"
+    return TRAP_PROFILES.get(k, TrapProfile(kind=k, name=k.replace("_", " ").title(), warning_signs=(), trigger_text="A hidden mechanism triggers!", damage="1d6"))
+
+
+def infer_trap_kind(room: dict[str, Any]) -> str:
+    trap = room.get("trap") if isinstance(room.get("trap"), dict) else {}
+    explicit = str(trap.get("kind") or room.get("trap_kind") or "").strip().lower()
+    if explicit:
+        return explicit
+    desc = str(room.get("trap_desc") or "").lower()
+    for token, kind in LEGACY_DESC_TO_KIND.items():
+        if token in desc:
+            return kind
+    return "pit"
+
+
+def ensure_trap_state(room: dict[str, Any]) -> dict[str, Any]:
+    trap = dict(room.get("trap") or {}) if isinstance(room.get("trap"), dict) else {}
+    kind = infer_trap_kind(room)
+    profile = trap_profile(kind)
+    trap.setdefault("kind", profile.kind)
+    trap.setdefault("found", bool(room.get("trap_found", False)))
+    trap.setdefault("triggered", bool(room.get("trap_triggered", False)))
+    trap.setdefault("disarmed", bool(room.get("trap_disarmed", False)))
+    trap.setdefault("disabled", bool(trap.get("disarmed", False) or trap.get("triggered", False)))
+    trap.setdefault("damage", str(room.get("trap_damage") or profile.damage))
+    trap.setdefault("alarm", bool(room.get("trap_alarm", profile.alarm)))
+    trap.setdefault("noise", int(profile.noise))
+    trap.setdefault("warning_signs", list(profile.warning_signs))
+    room["trap"] = trap
+    room["trap_kind"] = str(trap.get("kind") or profile.kind)
+    room["trap_desc"] = str(room.get("trap_desc") or profile.trigger_text)
+    room["trap_damage"] = str(trap.get("damage") or profile.damage)
+    room["trap_alarm"] = bool(trap.get("alarm", profile.alarm))
+    room["trap_found"] = bool(trap.get("found", False))
+    room["trap_triggered"] = bool(trap.get("triggered", False))
+    room["trap_disarmed"] = bool(trap.get("disarmed", False) or trap.get("disabled", False))
+    return trap
+
+
+def mark_trap_state(room: dict[str, Any], *, found: bool | None = None, triggered: bool | None = None, disarmed: bool | None = None, disabled: bool | None = None) -> dict[str, Any]:
+    trap = ensure_trap_state(room)
+    if found is not None:
+        trap["found"] = bool(found)
+    if triggered is not None:
+        trap["triggered"] = bool(triggered)
+    if disarmed is not None:
+        trap["disarmed"] = bool(disarmed)
+    if disabled is not None:
+        trap["disabled"] = bool(disabled)
+    trap["disabled"] = bool(trap.get("disabled", False) or trap.get("disarmed", False) or trap.get("triggered", False))
+    room["trap_found"] = bool(trap.get("found", False))
+    room["trap_triggered"] = bool(trap.get("triggered", False))
+    room["trap_disarmed"] = bool(trap.get("disarmed", False) or trap.get("disabled", False))
+    return trap

--- a/sww/game.py
+++ b/sww/game.py
@@ -3131,7 +3131,6 @@ class Game:
             return blocked
         room = self._ensure_room(self.current_room_id)
 
-        # Only meaningful if the room has a trap spec.
         has_trap = (room.get("type") == "trap") or bool(room.get("trap_desc")) or bool(room.get("trap_damage"))
         if not has_trap:
             self.ui.log("You find no traps.")
@@ -3144,21 +3143,13 @@ class Game:
 
         if room.get("trap_disarmed"):
             self.ui.log("You find no active traps.")
-            self.emit(
-                "dungeon_search_traps",
-                room_id=int(self.current_room_id),
-                found=bool(room.get("trap_found")),
-                disarmed=True,
-                triggered=bool(room.get("trap_triggered")),
-            )
+            self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=bool(room.get("trap_found")), disarmed=True, triggered=bool(room.get("trap_triggered")), trap_kind=str(trap.get("kind") or profile.kind))
             return CommandResult(status="info")
 
-        # Phase 1: detect (find) the trap.
         if not room.get("trap_found"):
             best, chance_pct = self._best_skill_user('Find/Remove Traps')
             chance_in_6 = 1
             if best and chance_pct > 0:
-                # Map percent to in-6 roughly.
                 chance_in_6 = max(1, min(5, (int(chance_pct) + 14) // 20))
             found = self.dice.in_6(chance_in_6)
             if found:
@@ -3167,6 +3158,8 @@ class Game:
                     d["trap_found"] = True
                     d["trap"] = dict(room.get("trap") or {})
                 self.ui.log(f"You discover signs of a {profile.name.lower()}!")
+                for line in list(trap.get("warning_signs") or profile.warning_signs):
+                    self.ui.log(str(line))
                 self.emit("dungeon_trap_found", room_id=int(self.current_room_id), trap_kind=str(trap.get("kind") or profile.kind))
             else:
                 self.ui.log("You find nothing suspicious.")
@@ -3174,14 +3167,55 @@ class Game:
                 self._sync_room_to_delta(int(room.get("id", self.current_room_id)), room)
             except Exception:
                 pass
-            self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=bool(found), disarmed=False, triggered=False)
+            self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=bool(found), disarmed=False, triggered=False, trap_kind=str(trap.get("kind") or profile.kind))
             return CommandResult(status="info")
 
-        # Phase 2: attempt to disarm (requires a Find/Remove Traps % skill user).
+        # Discovered trap interaction layer: choose how to handle an identified hazard.
+        opts = [
+            "Disarm trap (Skilled)",
+            "Bypass carefully",
+            "Trigger intentionally",
+            "Back",
+        ]
+        choice = int(self.ui.choose(f"Discovered {profile.name}", opts))
+        trap_kind = str(trap.get("kind") or profile.kind)
+
+        if choice == 3:
+            self.ui.log("You leave the trap undisturbed.")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="back")
+            return CommandResult(status="info")
+
+        if choice == 1:
+            # Bypass costs time and has a small deterministic mishap risk.
+            self.spend_dungeon_time(1, reason="trap_bypass")
+            bypass_risk = max(1, min(6, int(getattr(profile, "noise", 1) or 1)))
+            if self.dice.in_6(bypass_risk):
+                self.ui.log("You misjudge the safe path!")
+                self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="bypass", outcome="failed")
+                self._handle_room_trap(room, source="bypass_failure")
+                return CommandResult(status="info")
+            mark_trap_state(room, found=True)
+            if d is not None:
+                d["trap_found"] = True
+                d["trap"] = dict(room.get("trap") or {})
+            self.ui.log("You guide the party around the trap for now.")
+            try:
+                self._sync_room_to_delta(int(room.get("id", self.current_room_id)), room)
+            except Exception:
+                pass
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="bypass", outcome="safe")
+            return CommandResult(status="ok")
+
+        if choice == 2:
+            self.ui.log("You deliberately trigger the trap from a controlled position.")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="trigger_intentional")
+            self._handle_room_trap(room, source="intentional")
+            return CommandResult(status="info")
+
         thief, chance_pct = self._best_skill_user('Find/Remove Traps')
         if not thief or int(chance_pct or 0) <= 0:
             self.ui.log("You have found a trap, but no one is trained to disarm it.")
-            self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=True, disarmed=False, triggered=False)
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="disarm", outcome="unavailable")
             return CommandResult(status="error")
 
         chance_pct = int(chance_pct)
@@ -3194,7 +3228,8 @@ class Game:
                 d["cleared"] = True
                 d["trap"] = dict(room.get("trap") or {})
             self.ui.log(f"{thief.name} disarms the {profile.name.lower()}.")
-            self.emit("dungeon_trap_disarmed", room_id=int(self.current_room_id), by=str(thief.name))
+            self.emit("dungeon_trap_disarmed", room_id=int(self.current_room_id), by=str(thief.name), trap_kind=trap_kind)
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="disarm", outcome="success")
             try:
                 self._sync_room_to_delta(int(room.get("id", self.current_room_id)), room)
             except Exception:
@@ -3203,8 +3238,9 @@ class Game:
 
         self.ui.log(f"{thief.name} fails to disarm the trap ({roll}/{chance_pct})!")
         self.noise_level = min(5, self.noise_level + 1)
-        self._handle_room_trap(room)
-        self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=True, disarmed=False, triggered=True)
+        self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="disarm", outcome="failed")
+        self._handle_room_trap(room, source="disarm_failure")
+        self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=True, disarmed=False, triggered=True, trap_kind=trap_kind)
         return CommandResult(status="info")
 
     def _cmd_dungeon_sneak(self) -> CommandResult:

--- a/sww/game.py
+++ b/sww/game.py
@@ -35,6 +35,7 @@ from .coin_rewards import CoinDestination, grant_coin_reward
 from .reward_bundle import apply_reward_bundle, empty_reward_bundle, reward_bundle_add_coins, reward_bundle_add_item
 from .wilderness_context import resolve_travel_context, first_time_poi_resolution_key
 from .dungeon_context import resolve_room_interaction_context, first_time_room_resolution_key
+from .dungeon_traps import ensure_trap_state, mark_trap_state, trap_profile
 from .factions import generate_static_core_factions, assign_territories, generate_static_conflict_clocks, clamp_rep
 from .contracts import generate_contracts, Contract
 from .events import (
@@ -2886,7 +2887,7 @@ class Game:
                     pass
                 self.emit("room_resolved", room_id=int(self.current_room_id), room_type="treasure")
             elif room["type"] == "trap":
-                self._handle_room_trap(room)
+                self._handle_room_trap(room, source="disarm_failure")
                 try:
                     self._encounter_end_capture()
                 except Exception:
@@ -3138,6 +3139,8 @@ class Game:
             return CommandResult(status="info")
 
         d = room.get("_delta") if isinstance(room.get("_delta"), dict) else None
+        trap = ensure_trap_state(room)
+        profile = trap_profile(str(trap.get("kind") or "pit"))
 
         if room.get("trap_disarmed"):
             self.ui.log("You find no active traps.")
@@ -3159,11 +3162,12 @@ class Game:
                 chance_in_6 = max(1, min(5, (int(chance_pct) + 14) // 20))
             found = self.dice.in_6(chance_in_6)
             if found:
-                room["trap_found"] = True
+                mark_trap_state(room, found=True)
                 if d is not None:
                     d["trap_found"] = True
-                self.ui.log("You discover signs of a trap!")
-                self.emit("dungeon_trap_found", room_id=int(self.current_room_id))
+                    d["trap"] = dict(room.get("trap") or {})
+                self.ui.log(f"You discover signs of a {profile.name.lower()}!")
+                self.emit("dungeon_trap_found", room_id=int(self.current_room_id), trap_kind=str(trap.get("kind") or profile.kind))
             else:
                 self.ui.log("You find nothing suspicious.")
             try:
@@ -3183,12 +3187,13 @@ class Game:
         chance_pct = int(chance_pct)
         roll = self.dice.percent()
         if roll <= max(1, min(99, chance_pct)):
-            room["trap_disarmed"] = True
+            mark_trap_state(room, disarmed=True, disabled=True)
             room["cleared"] = True
             if d is not None:
                 d["trap_disarmed"] = True
                 d["cleared"] = True
-            self.ui.log(f"{thief.name} disarms the trap!")
+                d["trap"] = dict(room.get("trap") or {})
+            self.ui.log(f"{thief.name} disarms the {profile.name.lower()}.")
             self.emit("dungeon_trap_disarmed", room_id=int(self.current_room_id), by=str(thief.name))
             try:
                 self._sync_room_to_delta(int(room.get("id", self.current_room_id)), room)
@@ -3346,12 +3351,10 @@ class Game:
         dest_room = self._ensure_room(dest)
         # Passive entry checks do not cost time: automatic trap/secret checks on first entry.
         self._passive_room_entry_checks(dest_room)
-        # P6.1.2.0: trap rooms can trigger on entry unless previously found/disarmed.
+        # Trap rooms deterministically trigger on blind entry unless already found/disabled.
         if (dest_room.get("type") == "trap" or dest_room.get("trap_desc")) and not dest_room.get("trap_disarmed"):
             if not dest_room.get("trap_found") and not dest_room.get("trap_triggered"):
-                # Light touch: 2-in-6 chance to trigger when you blunder in.
-                if self.dice.in_6(2):
-                    self._handle_room_trap(dest_room)
+                self._handle_room_trap(dest_room, source="entry")
         self.ui.log(f"You move to Room {dest}.")
         self.emit("dungeon_moved", src=int(src), dest=int(dest), exit_key=str(key))
         return CommandResult(status="ok")
@@ -10989,48 +10992,48 @@ class Game:
             pass
 
     
-    def _handle_room_trap(self, room: dict[str, Any]):
+    def _handle_room_trap(self, room: dict[str, Any], *, source: str = "unknown"):
         ctx = resolve_room_interaction_context(self, room)
+        trap = ensure_trap_state(room)
+        profile = trap_profile(str(trap.get("kind") or "pit"))
         if room.get("trap_disarmed") or bool(ctx.get("hazards_resolved")):
             self.ui.log("A disarmed trap lies here.")
             room["cleared"] = True
             return
 
-        trap_key = str(room.get("trap_desc") or room.get("trap_damage") or "trap").strip().lower().replace(" ", "_")
+        trap_key = str(trap.get("kind") or room.get("trap_desc") or room.get("trap_damage") or "trap").strip().lower().replace(" ", "_")
         if not self._mark_room_resolution_once(room, f"trap:{trap_key}", mode="trigger"):
-            room["trap_disarmed"] = True
+            mark_trap_state(room, disarmed=True, disabled=True)
             room["cleared"] = True
             return
 
-        # Mark as triggered/found so it can't repeatedly fire.
-        room["trap_triggered"] = True
-        room["trap_found"] = True
-
+        mark_trap_state(room, found=True, triggered=True, disabled=True)
         d = room.get("_delta") if isinstance(room.get("_delta"), dict) else None
         if d is not None:
             d["trap_triggered"] = True
             d["trap_found"] = True
+            d["trap"] = dict(room.get("trap") or {})
 
         self.ui.title("Trap!")
-        self.ui.log(room.get("trap_desc", "A hidden mechanism triggers!"))
+        self.ui.log(str(room.get("trap_desc") or profile.trigger_text))
 
-        # Dwarf stonework notice (careful movement).
         try:
             from .races import dwarf_trap_notice_in_6
             ch = int(dwarf_trap_notice_in_6(self.party, mode="careful"))
             if ch > 0 and self.dice.in_6(ch):
                 self.ui.log("A dwarf notices subtle stonework tells — you avoid the trap!")
-                room["trap_disarmed"] = True
+                mark_trap_state(room, disarmed=True, disabled=True)
                 room["cleared"] = True
                 if d is not None:
                     d["trap_disarmed"] = True
                     d["cleared"] = True
-                self.emit("dungeon_trap_spotted", room_id=int(room.get("id", -1)), by_race="Dwarf")
+                    d["trap"] = dict(room.get("trap") or {})
+                self.emit("dungeon_trap_spotted", room_id=int(room.get("id", -1)), by_race="Dwarf", trap_kind=str(trap.get("kind") or profile.kind))
                 return
         except Exception:
             pass
 
-        dmg_expr = str(room.get("trap_damage") or "1d6")
+        dmg_expr = str(trap.get("damage") or room.get("trap_damage") or profile.damage)
         try:
             dmg = int(self.dice.roll(dmg_expr).total)
         except Exception:
@@ -11042,23 +11045,32 @@ class Game:
             self._notify_damage(victim, dmg, damage_types={"physical"})
             self.ui.log(f"{victim.name} takes {dmg} damage!")
 
-        room["trap_disarmed"] = True
+        mark_trap_state(room, disarmed=True, disabled=True)
         room["cleared"] = True
         if d is not None:
             d["trap_disarmed"] = True
             d["cleared"] = True
+            d["trap"] = dict(room.get("trap") or {})
 
-        # Alarm/noise.
-        if bool(room.get('trap_alarm')) or "alarm" in str(room.get("trap_desc") or "").lower() or self.dice.in_6(2):
-            self.noise_level = min(5, self.noise_level + 2)
+        if int(profile.extra_turn_cost) > 0:
+            self.spend_dungeon_time(int(profile.extra_turn_cost), reason=f"trap:{profile.kind}")
+            self.ui.log("The trap slows your party's advance.")
+        if int(profile.light_loss) > 0 and int(getattr(self, "torch_turns_left", 0) or 0) > 0:
+            self.torch_turns_left = max(0, int(self.torch_turns_left) - int(profile.light_loss))
+            self.ui.log("Your light sputters in the chaos.")
+
+        if bool(trap.get("alarm", profile.alarm)) or "alarm" in str(room.get("trap_desc") or "").lower():
+            self.noise_level = min(5, self.noise_level + max(1, int(profile.noise)))
             self._propagate_dungeon_alarm(origin_room_id=int(room.get('id', self.current_room_id) or self.current_room_id), severity=1, reason='trap alarm')
             self.ui.log("The trap makes a terrible racket!")
 
-        # Persist trap state to delta (important if the trap triggers during movement).
+        self.emit("dungeon_trap_triggered", room_id=int(room.get("id", self.current_room_id) or self.current_room_id), trap_kind=str(trap.get("kind") or profile.kind), source=str(source), damage=int(dmg), victim=str(getattr(victim, "name", "")) if victim else None)
+
         try:
             self._sync_room_to_delta(int(room.get("id", self.current_room_id)), room)
         except Exception:
             pass
+
 
     def _room_entry_signals(self, room: dict[str, Any]) -> list[str]:
         """Return 0-2 short, non-mechanical telegraph lines shown once on first entry.
@@ -11177,6 +11189,9 @@ class Game:
 
         # Passive trap detection before any trigger.
         has_trap = (room.get("type") == "trap") or bool(room.get("trap_desc")) or bool(room.get("trap_damage"))
+        if has_trap:
+            trap = ensure_trap_state(room)
+            profile = trap_profile(str(trap.get("kind") or "pit"))
         if has_trap and not room.get("trap_disarmed") and not room.get("trap_found"):
             found_by: list[str] = []
             for pc in self.party.pcs():
@@ -11198,12 +11213,14 @@ class Game:
                 if roll <= max(1, min(99, pct)):
                     found_by.append(str(getattr(pc, "name", "Someone")))
             if found_by:
-                room["trap_found"] = True
+                mark_trap_state(room, found=True)
                 if len(found_by) == 1:
                     self.ui.log(f"{found_by[0]} notices signs of a trap!")
+                    for line in list(trap.get("warning_signs") or profile.warning_signs):
+                        self.ui.log(str(line))
                 else:
                     self.ui.log("Your party notices signs of a trap!")
-                self.emit("dungeon_trap_found", room_id=rid)
+                self.emit("dungeon_trap_found", room_id=rid, trap_kind=str(trap.get("kind") or profile.kind))
 
 
         # Dwarf stonework trap noticing on first entry (no time cost).
@@ -11212,9 +11229,9 @@ class Game:
             if (room.get("type") == "trap" or room.get("trap_desc")) and not room.get("trap_found"):
                 ch = int(dwarf_trap_notice_in_6(self.party, mode="careful"))
                 if ch > 0 and self.dice.in_6(ch):
-                    room["trap_found"] = True
+                    mark_trap_state(room, found=True)
                     self.ui.log("A dwarf notices subtle stonework tells — there may be a trap here.")
-                    self.emit("dungeon_trap_found", room_id=rid, by_race="Dwarf")
+                    self.emit("dungeon_trap_found", room_id=rid, by_race="Dwarf", trap_kind=str(trap.get("kind") or profile.kind))
         except Exception:
             pass
 
@@ -11322,8 +11339,7 @@ class Game:
         # Keep UI-driven movement consistent with command-driven movement for traps.
         if (r2.get("type") == "trap" or r2.get("trap_desc")) and not r2.get("trap_disarmed"):
             if not r2.get("trap_found") and not r2.get("trap_triggered"):
-                if self.dice.in_6(2):
-                    self._handle_room_trap(r2)
+                self._handle_room_trap(r2, source="entry")
 
     # -------------
     # Dungeon generation + persistence
@@ -11600,6 +11616,7 @@ class Game:
             "trap_disarmed",
             "trap_found",
             "trap_triggered",
+            "trap_disabled",
             "secret_found",
             "entered",
             "event_done",
@@ -11614,6 +11631,12 @@ class Game:
 
         if isinstance(room.get("doors"), dict):
             rec["doors"] = dict(room.get("doors") or {})
+
+        if isinstance(room.get("trap"), dict) or isinstance(rec.get("trap"), dict):
+            trap = ensure_trap_state(room)
+            trap = mark_trap_state(room, found=bool(room.get("trap_found", trap.get("found", False))), triggered=bool(room.get("trap_triggered", trap.get("triggered", False))), disarmed=bool(room.get("trap_disarmed", trap.get("disarmed", False))), disabled=bool(room.get("trap_disarmed", False) or room.get("trap_triggered", False) or trap.get("disabled", False)))
+            rec["trap"] = dict(trap)
+            rec["trap_disabled"] = bool(trap.get("disabled", False))
 
         keys = room.get("resolution_keys", rec.get("resolution_keys", []))
         if isinstance(keys, (list, tuple, set)):
@@ -11685,6 +11708,7 @@ class Game:
                 drec.setdefault("trap_found", False)
                 drec.setdefault("trap_triggered", False)
                 drec.setdefault("trap_disarmed", False)
+                drec.setdefault("trap_disabled", bool(drec.get("trap_disarmed", False) or drec.get("trap_triggered", False)))
             drec.setdefault("secret_found", False)
 
             doors = drec.get("doors")
@@ -11732,6 +11756,9 @@ class Game:
                 room["trap_triggered"] = bool(drec.get("trap_triggered"))
             if "trap_disarmed" in drec:
                 room["trap_disarmed"] = bool(drec.get("trap_disarmed"))
+            if isinstance(drec.get("trap"), dict):
+                room["trap"] = dict(drec.get("trap") or {})
+                room["trap_kind"] = str(room["trap"].get("kind") or room.get("trap_kind") or "pit")
             for _k in ('event_done','feature_done','shrine_done','puzzle_done'):
                 if _k in drec:
                     room[_k] = bool(drec.get(_k))
@@ -11768,14 +11795,21 @@ class Game:
                     room.setdefault("trap_found", bool(drec.get("trap_found", False)))
                     room.setdefault("trap_triggered", bool(drec.get("trap_triggered", False)))
                     t = srec.get("trap") if isinstance(srec.get("trap"), dict) else {}
-                    kind = str((t or {}).get("trap_kind") or "trap").replace("_", " ")
-                    room["trap_desc"] = str((t or {}).get("desc") or f"A dangerous {kind}!")
+                    room.setdefault("trap", {})
+                    trap_kind = str((t or {}).get("trap_kind") or room.get("trap_kind") or "pit").strip().lower()
+                    profile = trap_profile(trap_kind)
+                    room["trap"]["kind"] = trap_kind
+                    room["trap_desc"] = str((t or {}).get("desc") or profile.trigger_text)
                     try:
                         room["trap_dc"] = int((t or {}).get("dc") or 10)
                     except Exception:
                         room["trap_dc"] = 10
-                    room["trap_damage"] = str((t or {}).get("damage") or "1d6")
-                    room["trap_alarm"] = bool((t or {}).get("alarm", False))
+                    room["trap_damage"] = str((t or {}).get("damage") or profile.damage)
+                    room["trap_alarm"] = bool((t or {}).get("alarm", profile.alarm))
+                    room["trap"]["warning_signs"] = list(profile.warning_signs)
+                    room["trap"]["damage"] = str(room["trap_damage"])
+                    room["trap"]["alarm"] = bool(room["trap_alarm"])
+                    ensure_trap_state(room)
 
                 if isinstance(srec.get('special_room'), dict):
                     room['special_room'] = dict(srec.get('special_room') or {})
@@ -11793,6 +11827,12 @@ class Game:
                     room['puzzle'] = dict(srec.get('puzzle') or {})
                     room.setdefault('puzzle_done', bool(drec.get('puzzle_done', False)))
                     room['title'] = str(room.get('title') or room['puzzle'].get('name') or room['type'].title())
+
+            if rtype == "trap":
+                ensure_trap_state(room)
+                mark_trap_state(room, found=bool(drec.get("trap_found", room.get("trap_found", False))), triggered=bool(drec.get("trap_triggered", room.get("trap_triggered", False))), disarmed=bool(drec.get("trap_disarmed", room.get("trap_disarmed", False))), disabled=bool(drec.get("trap_disabled", room.get("trap_disarmed", False) or room.get("trap_triggered", False))))
+                drec["trap"] = dict(room.get("trap") or {})
+                drec["trap_disabled"] = bool(room.get("trap", {}).get("disabled", False))
 
             # Persist delta defaults now that we have a complete room view.
             self._set_dungeon_delta_room(room_id, drec)
@@ -11881,13 +11921,15 @@ class Game:
                 foes = [self.encounters._mk_monster(m) for _ in range(1 + (1 if self.dice.in_6(3) else 0))]
             room["foes"] = foes
         elif rtype == "trap":
-            room["trap_desc"] = self.dice_rng.choice([
-                "A spray of darts!",
-                "A collapsing ceiling!",
-                "A pit opens beneath your feet!",
-                "A scything blade swings from the wall!",
-            ])
+            trap_kind = self.dice_rng.choice(["pit", "dart", "gas"])
+            profile = trap_profile(str(trap_kind))
+            room["trap_kind"] = str(trap_kind)
+            room["trap_desc"] = str(profile.trigger_text)
+            room["trap_damage"] = str(profile.damage)
+            room["trap_alarm"] = bool(profile.alarm)
             room["trap_disarmed"] = False
+            room["trap"] = {"kind": str(trap_kind), "warning_signs": list(profile.warning_signs), "damage": str(profile.damage), "alarm": bool(profile.alarm)}
+            ensure_trap_state(room)
         elif rtype == "treasure":
             room["treasure_taken"] = False
         else:

--- a/sww/game.py
+++ b/sww/game.py
@@ -9599,6 +9599,11 @@ class Game:
     # Dungeon
     # -------------
 
+    def _dungeon_hazard_hint(self, room: dict[str, Any]) -> str | None:
+        if self._room_has_discovered_active_trap(room):
+            return "Known hazard here."
+        return None
+
     def _dungeon_action_labels(self, room: dict[str, Any]) -> tuple[list[str], bool]:
         discovered_active_trap = self._room_has_discovered_active_trap(room)
         actions = [
@@ -9637,6 +9642,9 @@ class Game:
             alarm = int((getattr(self, "dungeon_alarm_by_level", {}) or {}).get(lvl, 0))
             self.ui.log(f"Turn {self.dungeon_turn} | {self._dungeon_pressure_summary()}")
             self.ui.log(f"Room {self.current_room_id}: {room['type']} | Visited {room.get('visited', 0)}x")
+            hint = self._dungeon_hazard_hint(room)
+            if hint:
+                self.ui.log(hint)
             if room.get("cleared"):
                 self.ui.log("This room seems quiet (cleared).")
 

--- a/sww/game.py
+++ b/sww/game.py
@@ -75,6 +75,7 @@ from .commands import (
     DungeonListen,
     DungeonSearchSecret,
     DungeonSearchTraps,
+    DungeonInteractTrap,
     DungeonSneak,
     DungeonPrepareSpells,
     DungeonCastSpell,
@@ -3170,28 +3171,41 @@ class Game:
             self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=bool(found), disarmed=False, triggered=False, trap_kind=str(trap.get("kind") or profile.kind))
             return CommandResult(status="info")
 
-        # Discovered trap interaction layer: choose how to handle an identified hazard.
-        opts = [
-            "Disarm trap (Skilled)",
-            "Bypass carefully",
-            "Trigger intentionally",
-            "Back",
-        ]
-        choice = int(self.ui.choose(f"Discovered {profile.name}", opts))
+        return self._resolve_discovered_trap_interaction(room, source="search")
+
+    def _room_has_discovered_active_trap(self, room: dict[str, Any] | None = None) -> bool:
+        r = room if isinstance(room, dict) else self._ensure_room(self.current_room_id)
+        has_trap = (r.get("type") == "trap") or bool(r.get("trap_desc")) or bool(r.get("trap_damage"))
+        if not has_trap:
+            return False
+        trap = ensure_trap_state(r)
+        return bool(r.get("trap_found")) and not bool(r.get("trap_disarmed")) and not bool(trap.get("disabled", False))
+
+    def _resolve_discovered_trap_interaction(self, room: dict[str, Any], *, source: str) -> CommandResult:
+        trap = ensure_trap_state(room)
+        profile = trap_profile(str(trap.get("kind") or "pit"))
         trap_kind = str(trap.get("kind") or profile.kind)
+        d = room.get("_delta") if isinstance(room.get("_delta"), dict) else None
+
+        if not self._room_has_discovered_active_trap(room):
+            self.ui.log("No discovered active trap to interact with.")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="none", outcome="unavailable")
+            return CommandResult(status="error")
+
+        opts = ["Disarm trap (Skilled)", "Bypass carefully", "Trigger intentionally", "Back"]
+        choice = int(self.ui.choose(f"Discovered {profile.name}", opts))
 
         if choice == 3:
             self.ui.log("You leave the trap undisturbed.")
-            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="back")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="back")
             return CommandResult(status="info")
 
         if choice == 1:
-            # Bypass costs time and has a small deterministic mishap risk.
             self.spend_dungeon_time(1, reason="trap_bypass")
             bypass_risk = max(1, min(6, int(getattr(profile, "noise", 1) or 1)))
             if self.dice.in_6(bypass_risk):
                 self.ui.log("You misjudge the safe path!")
-                self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="bypass", outcome="failed")
+                self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="bypass", outcome="failed")
                 self._handle_room_trap(room, source="bypass_failure")
                 return CommandResult(status="info")
             mark_trap_state(room, found=True)
@@ -3203,19 +3217,19 @@ class Game:
                 self._sync_room_to_delta(int(room.get("id", self.current_room_id)), room)
             except Exception:
                 pass
-            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="bypass", outcome="safe")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="bypass", outcome="safe")
             return CommandResult(status="ok")
 
         if choice == 2:
             self.ui.log("You deliberately trigger the trap from a controlled position.")
-            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="trigger_intentional")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="trigger_intentional")
             self._handle_room_trap(room, source="intentional")
             return CommandResult(status="info")
 
         thief, chance_pct = self._best_skill_user('Find/Remove Traps')
         if not thief or int(chance_pct or 0) <= 0:
             self.ui.log("You have found a trap, but no one is trained to disarm it.")
-            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="disarm", outcome="unavailable")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="disarm", outcome="unavailable")
             return CommandResult(status="error")
 
         chance_pct = int(chance_pct)
@@ -3229,7 +3243,7 @@ class Game:
                 d["trap"] = dict(room.get("trap") or {})
             self.ui.log(f"{thief.name} disarms the {profile.name.lower()}.")
             self.emit("dungeon_trap_disarmed", room_id=int(self.current_room_id), by=str(thief.name), trap_kind=trap_kind)
-            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="disarm", outcome="success")
+            self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="disarm", outcome="success")
             try:
                 self._sync_room_to_delta(int(room.get("id", self.current_room_id)), room)
             except Exception:
@@ -3238,10 +3252,17 @@ class Game:
 
         self.ui.log(f"{thief.name} fails to disarm the trap ({roll}/{chance_pct})!")
         self.noise_level = min(5, self.noise_level + 1)
-        self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, choice="disarm", outcome="failed")
+        self.emit("dungeon_trap_choice", room_id=int(self.current_room_id), trap_kind=trap_kind, source=str(source), choice="disarm", outcome="failed")
         self._handle_room_trap(room, source="disarm_failure")
-        self.emit("dungeon_search_traps", room_id=int(self.current_room_id), found=True, disarmed=False, triggered=True, trap_kind=trap_kind)
         return CommandResult(status="info")
+
+    def _cmd_dungeon_interact_trap(self) -> CommandResult:
+        blocked = self._dungeon_precision_action_requires_light(action="interact with trap")
+        if blocked is not None:
+            return blocked
+        room = self._ensure_room(self.current_room_id)
+        return self._resolve_discovered_trap_interaction(room, source="interact")
+
 
     def _cmd_dungeon_sneak(self) -> CommandResult:
         blocked = self._dungeon_precision_action_requires_light(action="sneak safely")
@@ -9578,6 +9599,24 @@ class Game:
     # Dungeon
     # -------------
 
+    def _dungeon_action_labels(self, room: dict[str, Any]) -> tuple[list[str], bool]:
+        discovered_active_trap = self._room_has_discovered_active_trap(room)
+        actions = [
+            "Resume board-native map view",
+            "View map / mini-board",
+            "Listen at doors",
+            "Search for secret door",
+            "Search for traps (Skilled)",
+        ]
+        if discovered_active_trap:
+            actions.append("Interact with discovered trap")
+        actions += [
+            "Sneak (Skilled)",
+            "Prepare spells (camp)",
+            "Cast a spell (camp)",
+        ]
+        return actions, bool(discovered_active_trap)
+
     def dungeon_loop(self):
         # Dungeon loop migrated to command-driven flow (Step 4 refactor).
         self.dispatch(EnterDungeon())
@@ -9614,16 +9653,7 @@ class Game:
 
             stairs = room.get("stairs") or {}
 
-            actions = [
-                "Resume board-native map view",
-                "View map / mini-board",
-                "Listen at doors",
-                "Search for secret door",
-                "Search for traps (Skilled)",
-                "Sneak (Skilled)",
-                "Prepare spells (camp)",
-                "Cast a spell (camp)",
-            ]
+            actions, discovered_active_trap = self._dungeon_action_labels(room)
             if stairs.get("up"):
                 actions.append("Use stairs up")
             if stairs.get("down"):
@@ -9650,15 +9680,17 @@ class Game:
                 self.dispatch(DungeonSearchSecret())
             elif i == 4:
                 self.dispatch(DungeonSearchTraps())
-            elif i == 5:
+            elif i == 5 and discovered_active_trap:
+                self.dispatch(DungeonInteractTrap())
+            elif i == (6 if discovered_active_trap else 5):
                 self.dispatch(DungeonSneak())
-            elif i == 6:
+            elif i == (7 if discovered_active_trap else 6):
                 self.dispatch(DungeonPrepareSpells())
-            elif i == 7:
+            elif i == (8 if discovered_active_trap else 7):
                 self.dispatch(DungeonCastSpell())
             else:
                 # Handle stairs if present
-                idx = 8
+                idx = (9 if discovered_active_trap else 8)
                 if stairs.get("up"):
                     if i == idx:
                         self.dispatch(DungeonUseStairs("up"))

--- a/sww/systems/dungeon_system.py
+++ b/sww/systems/dungeon_system.py
@@ -8,6 +8,7 @@ from ..commands import (
     DungeonListen,
     DungeonSearchSecret,
     DungeonSearchTraps,
+    DungeonInteractTrap,
     DungeonSneak,
     DungeonPrepareSpells,
     DungeonCastSpell,
@@ -54,6 +55,9 @@ class DungeonSystem:
 
         if isinstance(cmd, DungeonSearchTraps):
             return g._cmd_dungeon_search_traps()
+
+        if isinstance(cmd, DungeonInteractTrap):
+            return g._cmd_dungeon_interact_trap()
 
         if isinstance(cmd, DungeonSneak):
             return g._cmd_dungeon_sneak()

--- a/tests/test_dungeon_trap_framework.py
+++ b/tests/test_dungeon_trap_framework.py
@@ -1,0 +1,152 @@
+from sww.game import Game
+from sww.ui_headless import HeadlessUI
+from sww.models import Actor
+from sww.save_load import game_to_dict, apply_game_dict
+
+
+def _new_game(seed: int = 4242) -> Game:
+    g = Game(HeadlessUI(), dice_seed=seed)
+    g._cmd_enter_dungeon()
+    return g
+
+
+def _find_room_id_by_type(g: Game, target: str) -> int:
+    ids = sorted(int(k) for k in (g.dungeon_instance.blueprint.data.get("rooms") or {}).keys())
+    for rid in ids:
+        room = g._ensure_room(rid)
+        if room.get("type") == target:
+            return rid
+    raise AssertionError(f"no room of type {target}")
+
+
+def _find_room_for_trap_framework(g: Game) -> int:
+    try:
+        return _find_room_id_by_type(g, "trap")
+    except AssertionError:
+        ids = sorted(int(k) for k in (g.dungeon_instance.blueprint.data.get("rooms") or {}).keys())
+        if not ids:
+            raise
+        rid = ids[0]
+        room = g._ensure_room(rid)
+        room["type"] = "trap"
+        room["trap_kind"] = "pit"
+        room["trap_desc"] = "The floor drops away into a pit!"
+        room["trap_damage"] = "1d6"
+        room["trap_disarmed"] = False
+        return rid
+
+
+def _find_neighbor(g: Game, rid: int) -> int:
+    adj = g._dungeon_bp_adjacency() or {}
+    nbs = list(adj.get(int(rid), []))
+    if not nbs:
+        raise AssertionError("trap room has no neighbors")
+    return int(sorted(nbs)[0])
+
+
+def _wire_open_exit(g: Game, src: int, dest: int) -> str:
+    room = g._ensure_room(src)
+    for k, v in (room.get("exits") or {}).items():
+        if int(v) == int(dest):
+            room.setdefault("doors", {})[str(k)] = "open"
+            return str(k)
+    key = "A"
+    room.setdefault("exits", {})[key] = int(dest)
+    room.setdefault("doors", {})[key] = "open"
+    return key
+
+
+def test_trap_passive_detection_records_found_and_warning_signs():
+    g = _new_game(101)
+    rid = _find_room_for_trap_framework(g)
+    room = g._ensure_room(rid)
+    room["entered"] = False
+    room["trap_kind"] = "dart"
+    room["trap"] = {"kind": "dart"}
+    room["trap_found"] = False
+    room["trap_disarmed"] = False
+
+    scout = Actor(name="Scout", hp=5, hp_max=5, ac_desc=8, hd=1, save=15, is_pc=True)
+    scout.thief_skills = {"Find/Remove Traps": 100}
+    g.party.members = [scout]
+
+    g._passive_room_entry_checks(room)
+
+    assert room.get("trap_found") is True
+    assert isinstance(room.get("trap"), dict)
+    assert room["trap"].get("kind") == "dart"
+    assert room["trap"].get("warning_signs")
+
+
+def test_trap_triggers_deterministically_on_blind_entry():
+    g = _new_game(202)
+    trap_rid = _find_room_for_trap_framework(g)
+    src = _find_neighbor(g, trap_rid)
+    exit_key = _wire_open_exit(g, src, trap_rid)
+
+    trap_room = g._ensure_room(trap_rid)
+    trap_room["trap_kind"] = "pit"
+    trap_room["trap"] = {"kind": "pit"}
+    trap_room["trap_found"] = False
+    trap_room["trap_triggered"] = False
+    trap_room["trap_disarmed"] = False
+
+    mover = Actor(name="Mover", hp=10, hp_max=10, ac_desc=8, hd=1, save=15, is_pc=True)
+    g.party.members = [mover]
+    g.current_room_id = src
+    before_hp = g.party.living()[0].hp
+    res = g._cmd_dungeon_move(exit_key)
+
+    assert res.ok
+    assert g.current_room_id == trap_rid
+    assert trap_room.get("trap_triggered") is True
+    assert trap_room.get("trap_disarmed") is True
+    assert g.party.living()[0].hp < before_hp
+
+
+def test_trap_state_persists_through_save_load_with_structured_trap_data():
+    g = _new_game(303)
+    rid = _find_room_for_trap_framework(g)
+    room = g._ensure_room(rid)
+    room["trap"] = {
+        "kind": "gas",
+        "found": True,
+        "triggered": True,
+        "disarmed": True,
+        "disabled": True,
+        "damage": "1d4",
+        "warning_signs": ["A faint acrid smell hangs in the stale air."],
+    }
+    room["trap_kind"] = "gas"
+    room["trap_found"] = True
+    room["trap_triggered"] = True
+    room["trap_disarmed"] = True
+    g._sync_room_to_delta(rid, room)
+
+    data = game_to_dict(g)
+    g2 = Game(HeadlessUI(), dice_seed=303)
+    apply_game_dict(g2, data)
+
+    room2 = g2._ensure_room(rid)
+    assert room2.get("trap_kind") == "gas"
+    assert room2.get("trap_found") is True
+    assert room2.get("trap_triggered") is True
+    assert room2.get("trap_disarmed") is True
+    assert (room2.get("trap") or {}).get("disabled") is True
+
+
+def test_trap_resolution_deterministic_with_fixed_seed():
+    def trap_snapshot(seed: int) -> tuple[str, str]:
+        g = _new_game(seed)
+        rid = _find_room_for_trap_framework(g)
+        room = g._ensure_room(rid)
+        room["trap_kind"] = room.get("trap_kind") or "dart"
+        room["trap"] = {"kind": room["trap_kind"]}
+        g._sync_room_to_delta(rid, room)
+        room2 = g._ensure_room(rid)
+        return str(room2.get("trap_kind") or ""), str((room2.get("trap") or {}).get("kind") or "")
+
+    k1, t1 = trap_snapshot(999)
+    k2, t2 = trap_snapshot(999)
+    assert k1 == k2
+    assert t1 == t2

--- a/tests/test_dungeon_trap_framework.py
+++ b/tests/test_dungeon_trap_framework.py
@@ -1,5 +1,6 @@
 from sww.game import Game
 from sww.ui_headless import HeadlessUI
+from sww.scripted_ui import ScriptedUI
 from sww.models import Actor
 from sww.save_load import game_to_dict, apply_game_dict
 
@@ -150,3 +151,98 @@ def test_trap_resolution_deterministic_with_fixed_seed():
     k2, t2 = trap_snapshot(999)
     assert k1 == k2
     assert t1 == t2
+
+
+def _setup_discovered_trap_game(seed: int, kind: str = "pit") -> tuple[Game, int, dict]:
+    g = Game(ScriptedUI(), dice_seed=seed)
+    g._cmd_enter_dungeon()
+    rid = _find_room_for_trap_framework(g)
+    room = g._ensure_room(rid)
+    room["type"] = "trap"
+    room["trap_kind"] = str(kind)
+    room["trap_desc"] = {
+        "pit": "The floor drops away into a pit!",
+        "dart": "Darts hiss out from hidden slits!",
+        "gas": "A cloud of choking gas floods the chamber!",
+    }.get(str(kind), "A hidden mechanism triggers!")
+    room["trap_damage"] = "1"
+    room["trap"] = {"kind": str(kind), "damage": "1", "found": True, "triggered": False, "disarmed": False, "disabled": False}
+    room["trap_found"] = True
+    room["trap_triggered"] = False
+    room["trap_disarmed"] = False
+    g.current_room_id = rid
+    g.torch_turns_left = 3
+    g.light_on = True
+    actor = Actor(name="Rogue", hp=10, hp_max=10, ac_desc=8, hd=1, save=15, is_pc=True)
+    actor.thief_skills = {"Find/Remove Traps": 100}
+    g.party.members = [actor]
+    return g, rid, room
+
+
+def test_discovered_trap_choice_bypass_safe_persists_found_not_disarmed():
+    g, rid, room = _setup_discovered_trap_game(1001, kind="pit")
+    ui = g.ui
+    assert isinstance(ui, ScriptedUI)
+    ui.push(1)  # Bypass carefully
+
+    res = g._cmd_dungeon_search_traps()
+    assert res.ok
+    assert room.get("trap_found") is True
+    assert room.get("trap_disarmed") is False
+    assert room.get("trap_triggered") is False
+
+    g._sync_room_to_delta(rid, room)
+    data = game_to_dict(g)
+    g2 = Game(HeadlessUI(), dice_seed=1001)
+    apply_game_dict(g2, data)
+    room2 = g2._ensure_room(rid)
+    assert room2.get("trap_found") is True
+    assert room2.get("trap_disarmed") is False
+    assert room2.get("trap_triggered") is False
+
+
+def test_discovered_trap_choice_disarm_marks_disarmed_and_persists():
+    g, rid, room = _setup_discovered_trap_game(1002, kind="dart")
+    ui = g.ui
+    assert isinstance(ui, ScriptedUI)
+    ui.push(0)  # Disarm trap
+
+    res = g._cmd_dungeon_search_traps()
+    assert res.ok
+    assert room.get("trap_disarmed") is True
+    assert room.get("trap_triggered") is False
+
+    g._sync_room_to_delta(rid, room)
+    data = game_to_dict(g)
+    g2 = Game(HeadlessUI(), dice_seed=1002)
+    apply_game_dict(g2, data)
+    room2 = g2._ensure_room(rid)
+    assert room2.get("trap_disarmed") is True
+
+
+def test_discovered_trap_choice_trigger_intentional_sets_triggered_and_disarmed():
+    g, _rid, room = _setup_discovered_trap_game(1003, kind="gas")
+    ui = g.ui
+    assert isinstance(ui, ScriptedUI)
+    ui.push(2)  # Trigger intentionally
+
+    before_hp = g.party.members[0].hp
+    g._cmd_dungeon_search_traps()
+
+    assert room.get("trap_triggered") is True
+    assert room.get("trap_disarmed") is True
+    assert g.party.members[0].hp <= before_hp
+
+
+def test_discovered_trap_choice_flow_deterministic_fixed_seed():
+    def run_once(seed: int) -> tuple[bool, bool, bool]:
+        g, _rid, room = _setup_discovered_trap_game(seed, kind="pit")
+        ui = g.ui
+        assert isinstance(ui, ScriptedUI)
+        ui.push(1)  # bypass
+        g._cmd_dungeon_search_traps()
+        return bool(room.get("trap_found")), bool(room.get("trap_triggered")), bool(room.get("trap_disarmed"))
+
+    a = run_once(1200)
+    b = run_once(1200)
+    assert a == b

--- a/tests/test_dungeon_trap_framework.py
+++ b/tests/test_dungeon_trap_framework.py
@@ -246,3 +246,44 @@ def test_discovered_trap_choice_flow_deterministic_fixed_seed():
     a = run_once(1200)
     b = run_once(1200)
     assert a == b
+
+
+def test_dedicated_trap_action_visibility_and_unavailability_after_resolve():
+    g, _rid, room = _setup_discovered_trap_game(1300, kind="pit")
+    actions, available = g._dungeon_action_labels(room)
+    assert available is True
+    assert "Interact with discovered trap" in actions
+
+    room["trap_disarmed"] = True
+    room["trap"]["disarmed"] = True
+    room["trap"]["disabled"] = True
+    actions2, available2 = g._dungeon_action_labels(room)
+    assert available2 is False
+    assert "Interact with discovered trap" not in actions2
+
+
+def test_dedicated_trap_action_routes_into_existing_choice_flow():
+    g, _rid, room = _setup_discovered_trap_game(1301, kind="dart")
+    ui = g.ui
+    assert isinstance(ui, ScriptedUI)
+    ui.push(0)  # Disarm via dedicated action
+
+    res = g._cmd_dungeon_interact_trap()
+    assert res.ok
+    assert room.get("trap_disarmed") is True
+
+
+def test_dedicated_trap_action_save_load_availability_continuity():
+    g, rid, room = _setup_discovered_trap_game(1302, kind="pit")
+    actions, available = g._dungeon_action_labels(room)
+    assert available is True
+    assert "Interact with discovered trap" in actions
+
+    g._sync_room_to_delta(rid, room)
+    data = game_to_dict(g)
+    g2 = Game(HeadlessUI(), dice_seed=1302)
+    apply_game_dict(g2, data)
+    room2 = g2._ensure_room(rid)
+    actions2, available2 = g2._dungeon_action_labels(room2)
+    assert available2 is True
+    assert "Interact with discovered trap" in actions2

--- a/tests/test_dungeon_trap_framework.py
+++ b/tests/test_dungeon_trap_framework.py
@@ -287,3 +287,35 @@ def test_dedicated_trap_action_save_load_availability_continuity():
     actions2, available2 = g2._dungeon_action_labels(room2)
     assert available2 is True
     assert "Interact with discovered trap" in actions2
+
+
+def test_hazard_hint_visible_for_discovered_active_trap():
+    g, _rid, room = _setup_discovered_trap_game(1400, kind="pit")
+    assert g._dungeon_hazard_hint(room) == "Known hazard here."
+
+
+def test_hazard_hint_absent_when_trap_undiscovered():
+    g, _rid, room = _setup_discovered_trap_game(1401, kind="pit")
+    room["trap_found"] = False
+    room["trap"]["found"] = False
+    assert g._dungeon_hazard_hint(room) is None
+
+
+def test_hazard_hint_absent_after_trap_resolved():
+    g, _rid, room = _setup_discovered_trap_game(1402, kind="pit")
+    room["trap_disarmed"] = True
+    room["trap"]["disarmed"] = True
+    room["trap"]["disabled"] = True
+    assert g._dungeon_hazard_hint(room) is None
+
+
+def test_hazard_hint_save_load_continuity_discovered_active():
+    g, rid, room = _setup_discovered_trap_game(1403, kind="pit")
+    assert g._dungeon_hazard_hint(room) == "Known hazard here."
+    g._sync_room_to_delta(rid, room)
+
+    data = game_to_dict(g)
+    g2 = Game(HeadlessUI(), dice_seed=1403)
+    apply_game_dict(g2, data)
+    room2 = g2._ensure_room(rid)
+    assert g2._dungeon_hazard_hint(room2) == "Known hazard here."


### PR DESCRIPTION
### Motivation
- Provide a small, reusable and deterministic trap subsystem to add non-combat risk and player choice during dungeon exploration. 
- Integrate with the existing dungeon light/time/pressure model and preservation/persistence model without altering high-level generator or faction systems. 
- Keep trap behaviors and state explicit and extensible so new trap kinds can be added without reworking room/delta persistence.

### Description
- Added a new trap module `sww/dungeon_traps.py` that defines `TrapProfile`, canonical trap profiles (`pit`, `dart`, `gas`), and helpers `ensure_trap_state` / `mark_trap_state` / `trap_profile` for normalizing and mutating structured trap state. 
- Integrated the framework into exploration flow in `sww/game.py` by refactoring trap resolution into `def _handle_room_trap(self, room, *, source=...)`, making blind-entry triggering deterministic, and surfacing trap-kind-aware messages and events. 
- Persisted structured trap data through the existing delta system by syncing `room['trap']` and `trap_disabled` in `_sync_room_to_delta` and rehydrating in `_ensure_room` and stocking paths (procedural/stocking traps now use `trap_profile`). 
- Added focused tests `tests/test_dungeon_trap_framework.py` covering passive discovery, blind-entry triggering, structured-state persistence across save/load, and deterministic snapshot behavior; changes are implemented to preserve compatibility with legacy trap fields.

### Testing
- Static compile: ran `python -m py_compile sww/game.py sww/dungeon_traps.py tests/test_dungeon_trap_framework.py` and it completed successfully. 
- Focused tests: ran `PYTHONPATH=. pytest -q tests/test_dungeon_trap_framework.py` and the new trap tests passed. 
- Regression and full suite: ran `PYTHONPATH=. pytest -q` and the full test suite passed with `244 passed`. 
- Targeted persistence checks: ran `PYTHONPATH=. pytest -q tests/test_dungeon_room_delta_persistence.py tests/test_dungeon_light_pressure.py` and they passed as part of the validation runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4203dca948328a1f0fb805b343672)