### PR TITLE
Add first reusable dungeon non-combat encounter framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Lint non-combat encounter content
+        run: PYTHONPATH=. python scripts/validate_noncombat_content_lint.py
+
+      - name: Run test suite
+        run: PYTHONPATH=. pytest -q

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ These artifacts are designed to support deterministic generation and save-game s
 
 ## Dev / tuning scripts
 
+- `PYTHONPATH=. python scripts/validate_noncombat_content_lint.py` — strict CI-style lint for built-in non-combat encounter content.
 - `python -m scripts.run_fixtures` — deterministic replay fixtures.
 - `python -m scripts.stress_test` — randomized stress sanity check.
 - `python -m scripts.xp_economy_report` — prints XP thresholds by class.

--- a/scripts/validate_noncombat_content_lint.py
+++ b/scripts/validate_noncombat_content_lint.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from sww.dungeon_noncombat import lint_authored_noncombat_content_for_ci
+
+
+def main() -> int:
+    issues = lint_authored_noncombat_content_for_ci()
+    if not issues:
+        print("noncombat content lint: OK")
+        return 0
+    print("noncombat content lint: FAIL")
+    for i, issue in enumerate(issues, 1):
+        print(
+            f"{i}. [{issue.get('code')}] archetype={issue.get('archetype','?')} path={issue.get('path','?')} :: {issue.get('message','')}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sww/commands.py
+++ b/sww/commands.py
@@ -215,6 +215,11 @@ class DungeonInteractTrap(Command):
 
 
 @dataclass(frozen=True)
+class DungeonInteractEncounter(Command):
+    pass
+
+
+@dataclass(frozen=True)
 class DungeonSneak(Command):
     pass
 

--- a/sww/dungeon_noncombat.py
+++ b/sww/dungeon_noncombat.py
@@ -4,6 +4,22 @@ from typing import Any
 
 
 Effect = dict[str, Any]
+LintIssue = dict[str, Any]
+
+
+_EFFECT_REQUIRED_FIELDS: dict[str, dict[str, type | tuple[type, ...]]] = {
+    "ration": {"delta": int},
+    "heal": {"amount": int},
+    "clue": {"clue_id": str},
+    "loot_item": {"item_name": str},
+    "loot_gp": {"gp": int},
+    "light": {"turns": int},
+    "noise": {"delta": int},
+    "mark": {"key": str},
+    "check": {"stat": str},
+    "resolve_hazard": {},
+    "noop": {},
+}
 
 
 def _norm_tags(ctx: dict[str, Any]) -> set[str]:
@@ -45,9 +61,54 @@ def normalize_effect(effect: Any) -> Effect:
     if isinstance(effect, dict):
         etype = str(effect.get("type") or "").strip().lower()
         if etype:
-            return dict(effect)
+            rec = dict(effect)
+            rec["type"] = etype
+            return rec
         return _eff("noop")
     return _parse_legacy_effect(str(effect or ""))
+
+
+def validate_effect(effect: Any, *, path: str = "effect") -> list[LintIssue]:
+    issues: list[LintIssue] = []
+    legacy = not isinstance(effect, dict)
+    rec = normalize_effect(effect)
+    etype = str(rec.get("type") or "").strip().lower()
+
+    if legacy:
+        issues.append({"level": "warning", "code": "legacy_effect_string", "path": path, "message": "Legacy string effect normalized to typed effect.", "effect": dict(rec)})
+
+    if etype not in _EFFECT_REQUIRED_FIELDS:
+        issues.append({"level": "warning", "code": "unknown_effect_type", "path": path, "message": f"Unknown non-combat effect type: {etype or '<missing>'}.", "effect": dict(rec)})
+        return issues
+
+    req = _EFFECT_REQUIRED_FIELDS[etype]
+    for key, expect_t in req.items():
+        if key not in rec:
+            issues.append({"level": "warning", "code": "missing_required_param", "path": f"{path}.{key}", "message": f"Missing required parameter '{key}' for effect type '{etype}'.", "effect": dict(rec)})
+            continue
+        if not isinstance(rec.get(key), expect_t):
+            tname = getattr(expect_t, "__name__", str(expect_t))
+            issues.append({"level": "warning", "code": "malformed_param_type", "path": f"{path}.{key}", "message": f"Parameter '{key}' must be {tname} for effect type '{etype}'.", "effect": dict(rec)})
+
+    if etype == "check":
+        stat = str(rec.get("stat") or "").strip().lower()
+        if stat and stat not in {"wis", "str"}:
+            issues.append({"level": "warning", "code": "unsupported_check_stat", "path": f"{path}.stat", "message": f"Check effect stat '{stat}' has no dedicated resolver behavior.", "effect": dict(rec)})
+
+    return issues
+
+
+def lint_encounter_effects(encounter: dict[str, Any] | None) -> list[LintIssue]:
+    issues: list[LintIssue] = []
+    enc = dict(encounter or {})
+    for ci, ch in enumerate(enc.get("choices") or []):
+        if not isinstance(ch, dict):
+            issues.append({"level": "warning", "code": "malformed_choice", "path": f"choices[{ci}]", "message": "Encounter choice must be an object.", "effect": None})
+            continue
+        effects = list(ch.get("effects") or [])
+        for ei, eff in enumerate(effects):
+            issues.extend(validate_effect(eff, path=f"choices[{ci}].effects[{ei}]"))
+    return issues
 
 
 def normalize_encounter(encounter: dict[str, Any] | None) -> dict[str, Any]:

--- a/sww/dungeon_noncombat.py
+++ b/sww/dungeon_noncombat.py
@@ -3,8 +3,69 @@ from __future__ import annotations
 from typing import Any
 
 
+Effect = dict[str, Any]
+
+
 def _norm_tags(ctx: dict[str, Any]) -> set[str]:
     return {str(t).strip().lower() for t in (ctx.get("room_tags") or []) if str(t).strip()}
+
+
+def _eff(etype: str, **params: Any) -> Effect:
+    rec: Effect = {"type": str(etype)}
+    rec.update(params)
+    return rec
+
+
+def _parse_legacy_effect(token: str) -> Effect:
+    tok = str(token or "").strip().lower()
+    if tok == "ration:-1":
+        return _eff("ration", delta=-1)
+    if tok.startswith("heal:"):
+        return _eff("heal", amount=int(tok.split(":", 1)[1] or 0))
+    if tok.startswith("clue:"):
+        return _eff("clue", clue_id=tok.split(":", 1)[1])
+    if tok.startswith("loot:item:"):
+        return _eff("loot_item", item_name=str(token).split(":", 2)[2])
+    if tok.startswith("loot:gp:"):
+        return _eff("loot_gp", gp=int(tok.split(":", 2)[2] or 0))
+    if tok.startswith("light:+"):
+        return _eff("light", turns=int(tok.split("+", 1)[1] or 0))
+    if tok.startswith("noise:"):
+        return _eff("noise", delta=int(tok.split(":", 1)[1] or 0))
+    if tok.startswith("mark:"):
+        return _eff("mark", key=tok.split(":", 1)[1], value=True)
+    if tok.startswith("check:"):
+        return _eff("check", stat=tok.split(":", 1)[1])
+    if tok == "resolve:hazard":
+        return _eff("resolve_hazard")
+    return _eff("noop", legacy_token=str(token))
+
+
+def normalize_effect(effect: Any) -> Effect:
+    if isinstance(effect, dict):
+        etype = str(effect.get("type") or "").strip().lower()
+        if etype:
+            return dict(effect)
+        return _eff("noop")
+    return _parse_legacy_effect(str(effect or ""))
+
+
+def normalize_encounter(encounter: dict[str, Any] | None) -> dict[str, Any]:
+    enc = dict(encounter or {})
+    choices = []
+    for ch in (enc.get("choices") or []):
+        if not isinstance(ch, dict):
+            continue
+        ch2 = dict(ch)
+        ch2["effects"] = [normalize_effect(e) for e in (ch.get("effects") or [])]
+        choices.append(ch2)
+    enc["choices"] = choices
+    if not isinstance(enc.get("history"), list):
+        enc["history"] = []
+    if not isinstance(enc.get("state"), dict):
+        enc["state"] = {}
+    enc["status"] = str(enc.get("status") or "active")
+    return enc
 
 
 def choose_archetype(*, room: dict[str, Any], ctx: dict[str, Any], role: str, world_seed: int) -> str:
@@ -32,60 +93,60 @@ def build_encounter(archetype: str, *, room: dict[str, Any], ctx: dict[str, Any]
     eid = f"nc:{archetype}:{rid}:{depth}"
 
     if archetype == "stranded_npc":
-        return {
+        return normalize_encounter({
             "id": eid,
             "archetype": archetype,
             "status": "active",
             "state": {"aid_given": False},
             "prompt": "A trapped delver begs for help but seems alert enough to bargain.",
             "choices": [
-                {"id": "aid", "label": "Share supplies and free them", "effects": ["ration:-1", "clue:stable_routes", "heal:2"], "resolve": True},
-                {"id": "question", "label": "Question them from a distance", "effects": ["clue:hidden_route", "noise:+1"], "resolve": True},
+                {"id": "aid", "label": "Share supplies and free them", "effects": [_eff("ration", delta=-1), _eff("clue", clue_id="stable_routes"), _eff("heal", amount=2)], "resolve": True},
+                {"id": "question", "label": "Question them from a distance", "effects": [_eff("clue", clue_id="hidden_route"), _eff("noise", delta=1)], "resolve": True},
                 {"id": "leave", "label": "Leave them and move on", "effects": [], "resolve": True},
             ],
             "history": [],
-        }
+        })
 
     if archetype == "neutral_creature":
-        return {
+        return normalize_encounter({
             "id": eid,
             "archetype": archetype,
             "status": "active",
             "state": {"observed": False},
             "prompt": "A creature watches from the rubble, uncertain but not attacking.",
             "choices": [
-                {"id": "observe", "label": "Observe quietly", "effects": ["mark:observed"], "resolve": False},
-                {"id": "calm", "label": "Offer a calming gesture", "effects": ["check:wis", "clue:creature_path"], "resolve": True},
-                {"id": "retreat", "label": "Back away slowly", "effects": ["noise:+0"], "resolve": True},
+                {"id": "observe", "label": "Observe quietly", "effects": [_eff("mark", key="observed", value=True)], "resolve": False},
+                {"id": "calm", "label": "Offer a calming gesture", "effects": [_eff("check", stat="wis"), _eff("clue", clue_id="creature_path")], "resolve": True},
+                {"id": "retreat", "label": "Back away slowly", "effects": [_eff("noise", delta=0)], "resolve": True},
             ],
             "history": [],
-        }
+        })
 
     if archetype == "omen_echo":
-        return {
+        return normalize_encounter({
             "id": eid,
             "archetype": archetype,
             "status": "active",
             "state": {},
             "prompt": "A cold omen ripples through the room, carrying fragments of old warnings.",
             "choices": [
-                {"id": "commune", "label": "Listen to the omen", "effects": ["clue:deeper_defense", "light:+2"], "resolve": True},
-                {"id": "record", "label": "Record the omen as field notes", "effects": ["loot:item:Annotated omen notes"], "resolve": True},
-                {"id": "ward", "label": "Trace protective signs and continue", "effects": ["resolve:hazard"], "resolve": True},
+                {"id": "commune", "label": "Listen to the omen", "effects": [_eff("clue", clue_id="deeper_defense"), _eff("light", turns=2)], "resolve": True},
+                {"id": "record", "label": "Record the omen as field notes", "effects": [_eff("loot_item", item_name="Annotated omen notes")], "resolve": True},
+                {"id": "ward", "label": "Trace protective signs and continue", "effects": [_eff("resolve_hazard")], "resolve": True},
             ],
             "history": [],
-        }
+        })
 
-    return {
+    return normalize_encounter({
         "id": eid,
         "archetype": "environmental_scene",
         "status": "active",
         "state": {},
         "prompt": "A collapsed section blocks easy movement; the room can be worked safely with care.",
         "choices": [
-            {"id": "clear", "label": "Clear a safer path", "effects": ["check:str", "noise:+1", "resolve:hazard"], "resolve": True},
-            {"id": "scavenge", "label": "Scavenge useful scraps", "effects": ["loot:gp:8", "noise:+1"], "resolve": True},
+            {"id": "clear", "label": "Clear a safer path", "effects": [_eff("check", stat="str"), _eff("noise", delta=1), _eff("resolve_hazard")], "resolve": True},
+            {"id": "scavenge", "label": "Scavenge useful scraps", "effects": [_eff("loot_gp", gp=8), _eff("noise", delta=1)], "resolve": True},
             {"id": "bypass", "label": "Bypass and leave it", "effects": [], "resolve": True},
         ],
         "history": [],
-    }
+    })

--- a/sww/dungeon_noncombat.py
+++ b/sww/dungeon_noncombat.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _norm_tags(ctx: dict[str, Any]) -> set[str]:
+    return {str(t).strip().lower() for t in (ctx.get("room_tags") or []) if str(t).strip()}
+
+
+def choose_archetype(*, room: dict[str, Any], ctx: dict[str, Any], role: str, world_seed: int) -> str:
+    """Deterministically choose a non-combat encounter archetype for this room."""
+    tags = _norm_tags(ctx)
+    kind = str((ctx.get("scene_kind") or "")).strip().lower()
+    rid = int(ctx.get("room_id", room.get("id", 0)) or 0)
+    depth = int(ctx.get("depth", room.get("depth", 1)) or 1)
+
+    if "shrine" in tags or "clue_target:boss" in tags or kind == "lore":
+        return "omen_echo"
+    if role in {"guard", "lair"} or kind == "occupant":
+        return "neutral_creature" if ((rid + depth + int(world_seed)) % 2 == 0) else "stranded_npc"
+    if "role:transit" in tags or kind == "rest":
+        return "environmental_scene"
+
+    pool = ["stranded_npc", "neutral_creature", "omen_echo", "environmental_scene"]
+    idx = (rid * 37 + depth * 13 + int(world_seed) * 3) % len(pool)
+    return pool[idx]
+
+
+def build_encounter(archetype: str, *, room: dict[str, Any], ctx: dict[str, Any]) -> dict[str, Any]:
+    rid = int(ctx.get("room_id", room.get("id", 0)) or 0)
+    depth = int(ctx.get("depth", room.get("depth", 1)) or 1)
+    eid = f"nc:{archetype}:{rid}:{depth}"
+
+    if archetype == "stranded_npc":
+        return {
+            "id": eid,
+            "archetype": archetype,
+            "status": "active",
+            "state": {"aid_given": False},
+            "prompt": "A trapped delver begs for help but seems alert enough to bargain.",
+            "choices": [
+                {"id": "aid", "label": "Share supplies and free them", "effects": ["ration:-1", "clue:stable_routes", "heal:2"], "resolve": True},
+                {"id": "question", "label": "Question them from a distance", "effects": ["clue:hidden_route", "noise:+1"], "resolve": True},
+                {"id": "leave", "label": "Leave them and move on", "effects": [], "resolve": True},
+            ],
+            "history": [],
+        }
+
+    if archetype == "neutral_creature":
+        return {
+            "id": eid,
+            "archetype": archetype,
+            "status": "active",
+            "state": {"observed": False},
+            "prompt": "A creature watches from the rubble, uncertain but not attacking.",
+            "choices": [
+                {"id": "observe", "label": "Observe quietly", "effects": ["mark:observed"], "resolve": False},
+                {"id": "calm", "label": "Offer a calming gesture", "effects": ["check:wis", "clue:creature_path"], "resolve": True},
+                {"id": "retreat", "label": "Back away slowly", "effects": ["noise:+0"], "resolve": True},
+            ],
+            "history": [],
+        }
+
+    if archetype == "omen_echo":
+        return {
+            "id": eid,
+            "archetype": archetype,
+            "status": "active",
+            "state": {},
+            "prompt": "A cold omen ripples through the room, carrying fragments of old warnings.",
+            "choices": [
+                {"id": "commune", "label": "Listen to the omen", "effects": ["clue:deeper_defense", "light:+2"], "resolve": True},
+                {"id": "record", "label": "Record the omen as field notes", "effects": ["loot:item:Annotated omen notes"], "resolve": True},
+                {"id": "ward", "label": "Trace protective signs and continue", "effects": ["resolve:hazard"], "resolve": True},
+            ],
+            "history": [],
+        }
+
+    return {
+        "id": eid,
+        "archetype": "environmental_scene",
+        "status": "active",
+        "state": {},
+        "prompt": "A collapsed section blocks easy movement; the room can be worked safely with care.",
+        "choices": [
+            {"id": "clear", "label": "Clear a safer path", "effects": ["check:str", "noise:+1", "resolve:hazard"], "resolve": True},
+            {"id": "scavenge", "label": "Scavenge useful scraps", "effects": ["loot:gp:8", "noise:+1"], "resolve": True},
+            {"id": "bypass", "label": "Bypass and leave it", "effects": [], "resolve": True},
+        ],
+        "history": [],
+    }

--- a/sww/dungeon_noncombat.py
+++ b/sww/dungeon_noncombat.py
@@ -6,6 +6,19 @@ from typing import Any
 Effect = dict[str, Any]
 LintIssue = dict[str, Any]
 
+BUILTIN_NONCOMBAT_ARCHETYPES: tuple[str, ...] = (
+    "stranded_npc",
+    "neutral_creature",
+    "omen_echo",
+    "environmental_scene",
+)
+
+CI_FATAL_LINT_CODES: tuple[str, ...] = (
+    "unknown_effect_type",
+    "missing_required_param",
+    "malformed_param_type",
+)
+
 
 _EFFECT_REQUIRED_FIELDS: dict[str, dict[str, type | tuple[type, ...]]] = {
     "ration": {"delta": int},
@@ -109,6 +122,34 @@ def lint_encounter_effects(encounter: dict[str, Any] | None) -> list[LintIssue]:
         for ei, eff in enumerate(effects):
             issues.extend(validate_effect(eff, path=f"choices[{ci}].effects[{ei}]"))
     return issues
+
+
+def filter_ci_fatal_lint_issues(
+    issues: list[LintIssue] | None,
+    *,
+    fatal_codes: set[str] | None = None,
+) -> list[LintIssue]:
+    allowed = set(fatal_codes or set(CI_FATAL_LINT_CODES))
+    return [dict(i) for i in (issues or []) if str((i or {}).get("code") or "") in allowed]
+
+
+def lint_authored_noncombat_content_for_ci() -> list[LintIssue]:
+    """Return CI-fatal lint issues for built-in authored non-combat encounter content.
+
+    Boundary: this scans built-in encounter templates only. Runtime legacy-shape
+    compatibility data is intentionally not treated as authored CI-fatal content.
+    """
+    out: list[LintIssue] = []
+    room = {"id": 1, "depth": 1}
+    ctx = {"room_id": 1, "depth": 1}
+    for archetype in BUILTIN_NONCOMBAT_ARCHETYPES:
+        enc = build_encounter(archetype, room=room, ctx=ctx)
+        issues = lint_encounter_effects(enc)
+        for issue in filter_ci_fatal_lint_issues(issues):
+            rec = dict(issue)
+            rec["archetype"] = str(archetype)
+            out.append(rec)
+    return out
 
 
 def normalize_encounter(encounter: dict[str, Any] | None) -> dict[str, Any]:

--- a/sww/game.py
+++ b/sww/game.py
@@ -40,6 +40,7 @@ from .dungeon_noncombat import (
     choose_archetype as choose_noncombat_archetype,
     build_encounter as build_noncombat_encounter,
     normalize_encounter as normalize_noncombat_encounter,
+    lint_encounter_effects as lint_noncombat_encounter_effects,
 )
 from .factions import generate_static_core_factions, assign_territories, generate_static_conflict_clocks, clamp_rep
 from .contracts import generate_contracts, Contract
@@ -3278,12 +3279,14 @@ class Game:
         if isinstance(existing, dict):
             norm = normalize_noncombat_encounter(existing)
             room["noncombat_encounter"] = norm
+            self._emit_noncombat_lint_issues(room=room, encounter=norm)
             return norm
         d = room.get("_delta") if isinstance(room.get("_delta"), dict) else None
         if isinstance(d, dict) and isinstance(d.get("noncombat_encounter"), dict):
             norm = normalize_noncombat_encounter(d.get("noncombat_encounter") or {})
             room["noncombat_encounter"] = dict(norm)
             d["noncombat_encounter"] = dict(norm)
+            self._emit_noncombat_lint_issues(room=room, encounter=norm)
             return room.get("noncombat_encounter")
         ctx = resolve_room_interaction_context(self, room)
         profile = self._resolve_room_scene_profile(room, ctx) or {}
@@ -3297,7 +3300,19 @@ class Game:
         room["noncombat_encounter"] = dict(enc)
         if isinstance(d, dict):
             d["noncombat_encounter"] = dict(enc)
+        self._emit_noncombat_lint_issues(room=room, encounter=enc)
         return room.get("noncombat_encounter")
+
+    def _emit_noncombat_lint_issues(self, *, room: dict[str, Any], encounter: dict[str, Any]) -> None:
+        issues = list(lint_noncombat_encounter_effects(encounter) or [])
+        if not issues:
+            return
+        self.emit(
+            "dungeon_noncombat_effect_lint",
+            room_id=int(room.get("id", self.current_room_id) or self.current_room_id),
+            encounter_id=str(encounter.get("id") or ""),
+            issues=list(issues),
+        )
 
     def _noncombat_effect_registry(self) -> dict[str, Any]:
         return {
@@ -3432,6 +3447,7 @@ class Game:
             return CommandResult(status="info")
         enc = normalize_noncombat_encounter(enc)
         room["noncombat_encounter"] = enc
+        self._emit_noncombat_lint_issues(room=room, encounter=enc)
         if str(enc.get("status") or "active") != "active":
             self.ui.log("This encounter has already been resolved.")
             return CommandResult(status="info")

--- a/sww/game.py
+++ b/sww/game.py
@@ -36,6 +36,7 @@ from .reward_bundle import apply_reward_bundle, empty_reward_bundle, reward_bund
 from .wilderness_context import resolve_travel_context, first_time_poi_resolution_key
 from .dungeon_context import resolve_room_interaction_context, first_time_room_resolution_key
 from .dungeon_traps import ensure_trap_state, mark_trap_state, trap_profile
+from .dungeon_noncombat import choose_archetype as choose_noncombat_archetype, build_encounter as build_noncombat_encounter
 from .factions import generate_static_core_factions, assign_territories, generate_static_conflict_clocks, clamp_rep
 from .contracts import generate_contracts, Contract
 from .events import (
@@ -76,6 +77,7 @@ from .commands import (
     DungeonSearchSecret,
     DungeonSearchTraps,
     DungeonInteractTrap,
+    DungeonInteractEncounter,
     DungeonSneak,
     DungeonPrepareSpells,
     DungeonCastSpell,
@@ -3262,6 +3264,156 @@ class Game:
             return blocked
         room = self._ensure_room(self.current_room_id)
         return self._resolve_discovered_trap_interaction(room, source="interact")
+
+    def _ensure_room_noncombat_encounter(self, room: dict[str, Any]) -> dict[str, Any] | None:
+        if not isinstance(room, dict):
+            return None
+        if room.get("foes") or room.get("trap_triggered"):
+            return None
+        existing = room.get("noncombat_encounter")
+        if isinstance(existing, dict):
+            return existing
+        d = room.get("_delta") if isinstance(room.get("_delta"), dict) else None
+        if isinstance(d, dict) and isinstance(d.get("noncombat_encounter"), dict):
+            room["noncombat_encounter"] = dict(d.get("noncombat_encounter") or {})
+            return room.get("noncombat_encounter")
+        ctx = resolve_room_interaction_context(self, room)
+        profile = self._resolve_room_scene_profile(room, ctx) or {}
+        kind = str(profile.get("kind") or "rest")
+        if kind in {"hazard", "secret"}:
+            return None
+        role = str(profile.get("role") or "")
+        ctx["scene_kind"] = kind
+        archetype = choose_noncombat_archetype(room=room, ctx=ctx, role=role, world_seed=int(getattr(self, "world_seed", 0) or 0))
+        enc = build_noncombat_encounter(str(archetype), room=room, ctx=ctx)
+        room["noncombat_encounter"] = dict(enc)
+        if isinstance(d, dict):
+            d["noncombat_encounter"] = dict(enc)
+        return room.get("noncombat_encounter")
+
+    def _resolve_noncombat_effects(self, *, room: dict[str, Any], encounter: dict[str, Any], effects: list[str], choice_id: str) -> list[str]:
+        notes: list[str] = []
+        rid = int(room.get("id", self.current_room_id) or self.current_room_id)
+        lvl = int(getattr(self, "dungeon_level", 1) or 1)
+        for raw in (effects or []):
+            eff = str(raw or "").strip().lower()
+            if not eff:
+                continue
+            if eff == "ration:-1":
+                before = int(getattr(self, "rations", 0) or 0)
+                self.rations = max(0, before - 1)
+                if before > 0:
+                    notes.append("You spend 1 ration to stabilize the survivor.")
+                else:
+                    notes.append("You have no rations to share, but still render aid.")
+            elif eff == "heal:2":
+                injured = [pc for pc in self.party.living() if int(getattr(pc, "hp", 0) or 0) < int(getattr(pc, "hp_max", 0) or 0)]
+                if injured:
+                    pc = injured[0]
+                    pc.hp = min(pc.hp_max, int(pc.hp) + 2)
+                    notes.append(f"{pc.name} recovers 2 HP while tending the encounter.")
+            elif eff == "clue:stable_routes":
+                self._record_dungeon_clue("The rescued delver marks stable side-passages nearby.", source="noncombat", room_id=rid, level=lvl)
+                notes.append("You gain a practical route warning.")
+            elif eff == "clue:hidden_route":
+                self._record_dungeon_clue("The witness points out cracked stone concealing a bypass.", source="noncombat", room_id=rid, level=lvl)
+                notes.append("You gain a clue about a hidden bypass.")
+            elif eff == "clue:creature_path":
+                self._record_dungeon_clue("Tracks suggest which corridors the local creature avoids.", source="noncombat", room_id=rid, level=lvl)
+                notes.append("You read the creature's movements for safer travel.")
+            elif eff == "clue:deeper_defense":
+                self._record_dungeon_clue("The omen hints where deeper defenders gather.", source="noncombat", room_id=rid, level=lvl)
+                notes.append("The omen leaves a useful warning.")
+            elif eff == "loot:item:annotated omen notes":
+                self._grant_room_loot(gp=0, items=["Annotated omen notes"], source="noncombat")
+                notes.append("You preserve the omen as annotated notes.")
+            elif eff == "loot:gp:8":
+                self._grant_room_loot(gp=8, items=[], source="noncombat")
+                notes.append("You recover a small cache while scavenging.")
+            elif eff == "light:+2":
+                self.magical_light_turns = max(int(getattr(self, "magical_light_turns", 0) or 0), 2)
+                self.light_on = True
+                notes.append("The encounter leaves behind a brief magical glow.")
+            elif eff == "noise:+1":
+                self.noise_level = min(5, int(getattr(self, "noise_level", 0) or 0) + 1)
+                notes.append("Your actions make enough noise to carry.")
+            elif eff == "noise:+0":
+                notes.append("You withdraw without drawing extra noise.")
+            elif eff == "mark:observed":
+                state = encounter.setdefault("state", {}) if isinstance(encounter, dict) else {}
+                state["observed"] = True
+                notes.append("You watch long enough to understand its behavior.")
+            elif eff == "check:wis":
+                best_wis = 0
+                for pc in self.party.living():
+                    st = getattr(pc, "stats", None)
+                    try:
+                        best_wis = max(best_wis, int(getattr(st, "WIS", 0) or 0))
+                    except Exception:
+                        pass
+                odds = max(1, min(5, 2 + max(0, mod_ability(best_wis))))
+                if self.dice.in_6(odds):
+                    notes.append("Your calm posture avoids provoking the creature.")
+                else:
+                    self.noise_level = min(5, int(getattr(self, "noise_level", 0) or 0) + 1)
+                    notes.append("The creature startles and the exchange grows tense.")
+            elif eff == "check:str":
+                best_str = 0
+                for pc in self.party.living():
+                    st = getattr(pc, "stats", None)
+                    try:
+                        best_str = max(best_str, int(getattr(st, "STR", 0) or 0))
+                    except Exception:
+                        pass
+                odds = max(1, min(5, 2 + max(0, mod_ability(best_str))))
+                if self.dice.in_6(odds):
+                    notes.append("You clear enough rubble to make movement safer.")
+                else:
+                    notes.append("The blockage only partly yields under your effort.")
+            elif eff == "resolve:hazard":
+                room["hazard_resolved"] = True
+                notes.append("This room's immediate hazard pressure is eased.")
+        self.emit("dungeon_noncombat_choice", room_id=rid, encounter_id=str(encounter.get("id") or ""), archetype=str(encounter.get("archetype") or ""), choice=str(choice_id), notes=list(notes))
+        return notes
+
+    def _resolve_noncombat_encounter(self, room: dict[str, Any], *, source: str) -> CommandResult:
+        enc = self._ensure_room_noncombat_encounter(room)
+        if not isinstance(enc, dict):
+            self.ui.log("No non-combat encounter needs attention here.")
+            return CommandResult(status="info")
+        if str(enc.get("status") or "active") != "active":
+            self.ui.log("This encounter has already been resolved.")
+            return CommandResult(status="info")
+        choices = [c for c in (enc.get("choices") or []) if isinstance(c, dict)]
+        if not choices:
+            self.ui.log("Nothing actionable remains in this encounter.")
+            return CommandResult(status="info")
+        self.ui.log(str(enc.get("prompt") or "Something unusual here invites caution."))
+        labels = [str(c.get("label") or c.get("id") or "Option") for c in choices]
+        pick = self.ui.choose("Non-combat encounter", labels)
+        chosen = choices[pick]
+        choice_id = str(chosen.get("id") or f"choice_{pick}")
+        notes = self._resolve_noncombat_effects(room=room, encounter=enc, effects=list(chosen.get("effects") or []), choice_id=choice_id)
+        hist = enc.setdefault("history", [])
+        if isinstance(hist, list):
+            hist.append({"source": str(source), "choice": choice_id, "notes": list(notes)})
+        if bool(chosen.get("resolve", True)):
+            enc["status"] = "resolved"
+        if isinstance(room.get("_delta"), dict):
+            room["_delta"]["noncombat_encounter"] = dict(enc)
+        self._sync_room_to_delta(int(room.get("id", self.current_room_id) or self.current_room_id), room)
+        for line in notes:
+            self.ui.log(line)
+        if str(enc.get("status") or "") == "resolved":
+            self.ui.log("The situation settles; no further non-combat choices remain.")
+        return CommandResult(status="ok")
+
+    def _cmd_dungeon_interact_encounter(self) -> CommandResult:
+        blocked = self._dungeon_precision_action_requires_light(action="interact with encounter")
+        if blocked is not None:
+            return blocked
+        room = self._ensure_room(self.current_room_id)
+        return self._resolve_noncombat_encounter(room, source="action")
 
 
     def _cmd_dungeon_sneak(self) -> CommandResult:
@@ -9602,10 +9754,15 @@ class Game:
     def _dungeon_hazard_hint(self, room: dict[str, Any]) -> str | None:
         if self._room_has_discovered_active_trap(room):
             return "Known hazard here."
+        enc = self._ensure_room_noncombat_encounter(room)
+        if isinstance(enc, dict) and str(enc.get("status") or "active") == "active":
+            return "Non-combat encounter present."
         return None
 
-    def _dungeon_action_labels(self, room: dict[str, Any]) -> tuple[list[str], bool]:
+    def _dungeon_action_labels(self, room: dict[str, Any]) -> tuple[list[str], bool, bool]:
         discovered_active_trap = self._room_has_discovered_active_trap(room)
+        enc = self._ensure_room_noncombat_encounter(room)
+        active_noncombat = isinstance(enc, dict) and str(enc.get("status") or "active") == "active"
         actions = [
             "Resume board-native map view",
             "View map / mini-board",
@@ -9615,12 +9772,14 @@ class Game:
         ]
         if discovered_active_trap:
             actions.append("Interact with discovered trap")
+        if active_noncombat:
+            actions.append("Interact with non-combat encounter")
         actions += [
             "Sneak (Skilled)",
             "Prepare spells (camp)",
             "Cast a spell (camp)",
         ]
-        return actions, bool(discovered_active_trap)
+        return actions, bool(discovered_active_trap), bool(active_noncombat)
 
     def dungeon_loop(self):
         # Dungeon loop migrated to command-driven flow (Step 4 refactor).
@@ -9661,7 +9820,7 @@ class Game:
 
             stairs = room.get("stairs") or {}
 
-            actions, discovered_active_trap = self._dungeon_action_labels(room)
+            actions, discovered_active_trap, active_noncombat = self._dungeon_action_labels(room)
             if stairs.get("up"):
                 actions.append("Use stairs up")
             if stairs.get("down"):
@@ -9690,15 +9849,17 @@ class Game:
                 self.dispatch(DungeonSearchTraps())
             elif i == 5 and discovered_active_trap:
                 self.dispatch(DungeonInteractTrap())
-            elif i == (6 if discovered_active_trap else 5):
+            elif i == (5 + (1 if discovered_active_trap else 0)) and active_noncombat:
+                self.dispatch(DungeonInteractEncounter())
+            elif i == (6 + (1 if discovered_active_trap else 0) + (1 if active_noncombat else 0)):
                 self.dispatch(DungeonSneak())
-            elif i == (7 if discovered_active_trap else 6):
+            elif i == (7 + (1 if discovered_active_trap else 0) + (1 if active_noncombat else 0)):
                 self.dispatch(DungeonPrepareSpells())
-            elif i == (8 if discovered_active_trap else 7):
+            elif i == (8 + (1 if discovered_active_trap else 0) + (1 if active_noncombat else 0)):
                 self.dispatch(DungeonCastSpell())
             else:
                 # Handle stairs if present
-                idx = (9 if discovered_active_trap else 8)
+                idx = 8 + (1 if discovered_active_trap else 0) + (1 if active_noncombat else 0)
                 if stairs.get("up"):
                     if i == idx:
                         self.dispatch(DungeonUseStairs("up"))
@@ -10706,44 +10867,15 @@ class Game:
                 self._record_dungeon_clue("A concealed route branches from this room.", source="secret_scene", room_id=rid, level=int(getattr(self, "dungeon_level", 1) or 1))
             return
 
-        if kind == "lore":
-            target = "deeper defenses" if "clue_target:boss" in set(ctx.get("room_tags") or []) else "hidden caches"
-            if not self._mark_room_resolution_once(room, f"lore:{target}", mode="scene"):
-                return
-            c = self.ui.choose("Lore scene", ["Study inscriptions", "Take charcoal rubbing", "Ignore and move on"])
-            if c == 2:
-                return
-            clue = f"Old markings hint at {target} beyond this level."
-            self._record_dungeon_clue(clue, source="lore_scene", room_id=rid, level=int(getattr(self, "dungeon_level", 1) or 1))
-            if c == 1:
-                self._grant_room_loot(gp=6, items=["Rubbing of warning sigils"], source="lore_scene")
+        enc = self._ensure_room_noncombat_encounter(room)
+        if not isinstance(enc, dict):
             return
-
-        if kind == "occupant":
-            if not self._mark_room_resolution_once(room, "passive-occupant", mode="scene"):
-                return
-            self.ui.log("A wary non-hostile occupant freezes in the torchlight.")
-            c = self.ui.choose("Occupant reaction", ["Offer aid", "Ask for warning", "Drive them off", "Leave quietly"])
-            if c == 0:
-                injured = [pc for pc in self.party.living() if pc.hp < pc.hp_max]
-                if injured:
-                    pc = injured[0]
-                    pc.hp = min(pc.hp_max, pc.hp + 2)
-                    self.ui.log(f"{pc.name} is steadied with rough field dressing (+2 HP).")
-                self._record_dungeon_clue("A survivor warns of unstable floors nearby.", source="occupant_scene", room_id=rid, level=int(getattr(self, "dungeon_level", 1) or 1))
-            elif c == 1:
-                self._record_dungeon_clue("A frightened delver mentions a hidden bypass behind cracked stone.", source="occupant_scene", room_id=rid, level=int(getattr(self, "dungeon_level", 1) or 1))
-            elif c == 2:
-                self.noise_level = min(5, int(getattr(self, "noise_level", 0) or 0) + 1)
-                self.ui.log("Your threats echo through the halls.")
+        announce_key = f"noncombat-intro:{str(enc.get('id') or 'encounter')}"
+        if not self._mark_room_resolution_once(room, announce_key, mode="scene"):
             return
-
-        if not self._mark_room_resolution_once(room, "staging-room", mode="scene"):
-            return
-        if bool(ctx.get("party_ready", True)):
-            self.ui.log("You find a brief staging moment to regroup and check routes.")
-        else:
-            self.ui.log("The room is calm enough for a quick breath before pressing on.")
+        prompt = str(enc.get("prompt") or "A non-combat situation here might be worth handling.")
+        self.ui.log(prompt)
+        self.ui.log("Use 'Interact with non-combat encounter' for explicit choices.")
 
 
     def _ingest_reward_items_to_loot_pool(
@@ -11714,6 +11846,9 @@ class Game:
             rec["trap"] = dict(trap)
             rec["trap_disabled"] = bool(trap.get("disabled", False))
 
+        if isinstance(room.get("noncombat_encounter"), dict) or isinstance(rec.get("noncombat_encounter"), dict):
+            rec["noncombat_encounter"] = dict(room.get("noncombat_encounter") or rec.get("noncombat_encounter") or {})
+
         keys = room.get("resolution_keys", rec.get("resolution_keys", []))
         if isinstance(keys, (list, tuple, set)):
             rec["resolution_keys"] = sorted({str(x) for x in keys if str(x).strip()})
@@ -11835,6 +11970,8 @@ class Game:
             if isinstance(drec.get("trap"), dict):
                 room["trap"] = dict(drec.get("trap") or {})
                 room["trap_kind"] = str(room["trap"].get("kind") or room.get("trap_kind") or "pit")
+            if isinstance(drec.get("noncombat_encounter"), dict):
+                room["noncombat_encounter"] = dict(drec.get("noncombat_encounter") or {})
             for _k in ('event_done','feature_done','shrine_done','puzzle_done'):
                 if _k in drec:
                     room[_k] = bool(drec.get(_k))

--- a/sww/game.py
+++ b/sww/game.py
@@ -36,7 +36,11 @@ from .reward_bundle import apply_reward_bundle, empty_reward_bundle, reward_bund
 from .wilderness_context import resolve_travel_context, first_time_poi_resolution_key
 from .dungeon_context import resolve_room_interaction_context, first_time_room_resolution_key
 from .dungeon_traps import ensure_trap_state, mark_trap_state, trap_profile
-from .dungeon_noncombat import choose_archetype as choose_noncombat_archetype, build_encounter as build_noncombat_encounter
+from .dungeon_noncombat import (
+    choose_archetype as choose_noncombat_archetype,
+    build_encounter as build_noncombat_encounter,
+    normalize_encounter as normalize_noncombat_encounter,
+)
 from .factions import generate_static_core_factions, assign_territories, generate_static_conflict_clocks, clamp_rep
 from .contracts import generate_contracts, Contract
 from .events import (
@@ -3272,10 +3276,14 @@ class Game:
             return None
         existing = room.get("noncombat_encounter")
         if isinstance(existing, dict):
-            return existing
+            norm = normalize_noncombat_encounter(existing)
+            room["noncombat_encounter"] = norm
+            return norm
         d = room.get("_delta") if isinstance(room.get("_delta"), dict) else None
         if isinstance(d, dict) and isinstance(d.get("noncombat_encounter"), dict):
-            room["noncombat_encounter"] = dict(d.get("noncombat_encounter") or {})
+            norm = normalize_noncombat_encounter(d.get("noncombat_encounter") or {})
+            room["noncombat_encounter"] = dict(norm)
+            d["noncombat_encounter"] = dict(norm)
             return room.get("noncombat_encounter")
         ctx = resolve_room_interaction_context(self, room)
         profile = self._resolve_room_scene_profile(room, ctx) or {}
@@ -3285,94 +3293,135 @@ class Game:
         role = str(profile.get("role") or "")
         ctx["scene_kind"] = kind
         archetype = choose_noncombat_archetype(room=room, ctx=ctx, role=role, world_seed=int(getattr(self, "world_seed", 0) or 0))
-        enc = build_noncombat_encounter(str(archetype), room=room, ctx=ctx)
+        enc = normalize_noncombat_encounter(build_noncombat_encounter(str(archetype), room=room, ctx=ctx))
         room["noncombat_encounter"] = dict(enc)
         if isinstance(d, dict):
             d["noncombat_encounter"] = dict(enc)
         return room.get("noncombat_encounter")
 
-    def _resolve_noncombat_effects(self, *, room: dict[str, Any], encounter: dict[str, Any], effects: list[str], choice_id: str) -> list[str]:
-        notes: list[str] = []
+    def _noncombat_effect_registry(self) -> dict[str, Any]:
+        return {
+            "ration": self._resolve_noncombat_effect_ration,
+            "heal": self._resolve_noncombat_effect_heal,
+            "clue": self._resolve_noncombat_effect_clue,
+            "loot_item": self._resolve_noncombat_effect_loot_item,
+            "loot_gp": self._resolve_noncombat_effect_loot_gp,
+            "light": self._resolve_noncombat_effect_light,
+            "noise": self._resolve_noncombat_effect_noise,
+            "mark": self._resolve_noncombat_effect_mark,
+            "check": self._resolve_noncombat_effect_check,
+            "resolve_hazard": self._resolve_noncombat_effect_resolve_hazard,
+            "noop": self._resolve_noncombat_effect_noop,
+        }
+
+    def _resolve_noncombat_effect_ration(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        delta = int(effect.get("delta", 0) or 0)
+        before = int(getattr(self, "rations", 0) or 0)
+        self.rations = max(0, before + delta)
+        if delta < 0:
+            if before > 0:
+                notes.append(f"You spend {abs(delta)} ration{'s' if abs(delta) != 1 else ''} to stabilize the survivor.")
+            else:
+                notes.append("You have no rations to share, but still render aid.")
+
+    def _resolve_noncombat_effect_heal(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        amt = max(0, int(effect.get("amount", 0) or 0))
+        injured = [pc for pc in self.party.living() if int(getattr(pc, "hp", 0) or 0) < int(getattr(pc, "hp_max", 0) or 0)]
+        if injured and amt > 0:
+            pc = injured[0]
+            pc.hp = min(pc.hp_max, int(pc.hp) + amt)
+            notes.append(f"{pc.name} recovers {amt} HP while tending the encounter.")
+
+    def _resolve_noncombat_effect_clue(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
         rid = int(room.get("id", self.current_room_id) or self.current_room_id)
         lvl = int(getattr(self, "dungeon_level", 1) or 1)
-        for raw in (effects or []):
-            eff = str(raw or "").strip().lower()
-            if not eff:
-                continue
-            if eff == "ration:-1":
-                before = int(getattr(self, "rations", 0) or 0)
-                self.rations = max(0, before - 1)
-                if before > 0:
-                    notes.append("You spend 1 ration to stabilize the survivor.")
-                else:
-                    notes.append("You have no rations to share, but still render aid.")
-            elif eff == "heal:2":
-                injured = [pc for pc in self.party.living() if int(getattr(pc, "hp", 0) or 0) < int(getattr(pc, "hp_max", 0) or 0)]
-                if injured:
-                    pc = injured[0]
-                    pc.hp = min(pc.hp_max, int(pc.hp) + 2)
-                    notes.append(f"{pc.name} recovers 2 HP while tending the encounter.")
-            elif eff == "clue:stable_routes":
-                self._record_dungeon_clue("The rescued delver marks stable side-passages nearby.", source="noncombat", room_id=rid, level=lvl)
-                notes.append("You gain a practical route warning.")
-            elif eff == "clue:hidden_route":
-                self._record_dungeon_clue("The witness points out cracked stone concealing a bypass.", source="noncombat", room_id=rid, level=lvl)
-                notes.append("You gain a clue about a hidden bypass.")
-            elif eff == "clue:creature_path":
-                self._record_dungeon_clue("Tracks suggest which corridors the local creature avoids.", source="noncombat", room_id=rid, level=lvl)
-                notes.append("You read the creature's movements for safer travel.")
-            elif eff == "clue:deeper_defense":
-                self._record_dungeon_clue("The omen hints where deeper defenders gather.", source="noncombat", room_id=rid, level=lvl)
-                notes.append("The omen leaves a useful warning.")
-            elif eff == "loot:item:annotated omen notes":
-                self._grant_room_loot(gp=0, items=["Annotated omen notes"], source="noncombat")
-                notes.append("You preserve the omen as annotated notes.")
-            elif eff == "loot:gp:8":
-                self._grant_room_loot(gp=8, items=[], source="noncombat")
-                notes.append("You recover a small cache while scavenging.")
-            elif eff == "light:+2":
-                self.magical_light_turns = max(int(getattr(self, "magical_light_turns", 0) or 0), 2)
-                self.light_on = True
-                notes.append("The encounter leaves behind a brief magical glow.")
-            elif eff == "noise:+1":
+        cid = str(effect.get("clue_id") or "").strip().lower()
+        table = {
+            "stable_routes": ("The rescued delver marks stable side-passages nearby.", "You gain a practical route warning."),
+            "hidden_route": ("The witness points out cracked stone concealing a bypass.", "You gain a clue about a hidden bypass."),
+            "creature_path": ("Tracks suggest which corridors the local creature avoids.", "You read the creature's movements for safer travel."),
+            "deeper_defense": ("The omen hints where deeper defenders gather.", "The omen leaves a useful warning."),
+        }
+        clue_txt, note_txt = table.get(cid, ("You piece together a useful dungeon clue.", "You gain a useful clue."))
+        self._record_dungeon_clue(clue_txt, source="noncombat", room_id=rid, level=lvl)
+        notes.append(note_txt)
+
+    def _resolve_noncombat_effect_loot_item(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        item = str(effect.get("item_name") or "").strip()
+        if item:
+            self._grant_room_loot(gp=0, items=[item], source="noncombat")
+            notes.append("You preserve the omen as annotated notes." if item.lower() == "annotated omen notes" else f"You secure {item}.")
+
+    def _resolve_noncombat_effect_loot_gp(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        gp = max(0, int(effect.get("gp", 0) or 0))
+        if gp > 0:
+            self._grant_room_loot(gp=gp, items=[], source="noncombat")
+            notes.append("You recover a small cache while scavenging.")
+
+    def _resolve_noncombat_effect_light(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        turns = max(0, int(effect.get("turns", 0) or 0))
+        if turns > 0:
+            self.magical_light_turns = max(int(getattr(self, "magical_light_turns", 0) or 0), turns)
+            self.light_on = True
+            notes.append("The encounter leaves behind a brief magical glow.")
+
+    def _resolve_noncombat_effect_noise(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        delta = int(effect.get("delta", 0) or 0)
+        self.noise_level = max(0, min(5, int(getattr(self, "noise_level", 0) or 0) + delta))
+        if delta > 0:
+            notes.append("Your actions make enough noise to carry.")
+        elif delta == 0:
+            notes.append("You withdraw without drawing extra noise.")
+
+    def _resolve_noncombat_effect_mark(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        key = str(effect.get("key") or "").strip().lower()
+        if not key:
+            return
+        state = encounter.setdefault("state", {}) if isinstance(encounter, dict) else {}
+        state[key] = effect.get("value", True)
+        if key == "observed":
+            notes.append("You watch long enough to understand its behavior.")
+
+    def _resolve_noncombat_effect_check(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        stat_key = str(effect.get("stat") or "").strip().upper()
+        best = 0
+        for pc in self.party.living():
+            st = getattr(pc, "stats", None)
+            try:
+                best = max(best, int(getattr(st, stat_key, 0) or 0))
+            except Exception:
+                pass
+        odds = max(1, min(5, 2 + max(0, mod_ability(best))))
+        ok = bool(self.dice.in_6(odds))
+        if stat_key == "WIS":
+            if ok:
+                notes.append("Your calm posture avoids provoking the creature.")
+            else:
                 self.noise_level = min(5, int(getattr(self, "noise_level", 0) or 0) + 1)
-                notes.append("Your actions make enough noise to carry.")
-            elif eff == "noise:+0":
-                notes.append("You withdraw without drawing extra noise.")
-            elif eff == "mark:observed":
-                state = encounter.setdefault("state", {}) if isinstance(encounter, dict) else {}
-                state["observed"] = True
-                notes.append("You watch long enough to understand its behavior.")
-            elif eff == "check:wis":
-                best_wis = 0
-                for pc in self.party.living():
-                    st = getattr(pc, "stats", None)
-                    try:
-                        best_wis = max(best_wis, int(getattr(st, "WIS", 0) or 0))
-                    except Exception:
-                        pass
-                odds = max(1, min(5, 2 + max(0, mod_ability(best_wis))))
-                if self.dice.in_6(odds):
-                    notes.append("Your calm posture avoids provoking the creature.")
-                else:
-                    self.noise_level = min(5, int(getattr(self, "noise_level", 0) or 0) + 1)
-                    notes.append("The creature startles and the exchange grows tense.")
-            elif eff == "check:str":
-                best_str = 0
-                for pc in self.party.living():
-                    st = getattr(pc, "stats", None)
-                    try:
-                        best_str = max(best_str, int(getattr(st, "STR", 0) or 0))
-                    except Exception:
-                        pass
-                odds = max(1, min(5, 2 + max(0, mod_ability(best_str))))
-                if self.dice.in_6(odds):
-                    notes.append("You clear enough rubble to make movement safer.")
-                else:
-                    notes.append("The blockage only partly yields under your effort.")
-            elif eff == "resolve:hazard":
-                room["hazard_resolved"] = True
-                notes.append("This room's immediate hazard pressure is eased.")
+                notes.append("The creature startles and the exchange grows tense.")
+        elif stat_key == "STR":
+            if ok:
+                notes.append("You clear enough rubble to make movement safer.")
+            else:
+                notes.append("The blockage only partly yields under your effort.")
+
+    def _resolve_noncombat_effect_resolve_hazard(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        room["hazard_resolved"] = True
+        notes.append("This room's immediate hazard pressure is eased.")
+
+    def _resolve_noncombat_effect_noop(self, *, effect: dict[str, Any], room: dict[str, Any], encounter: dict[str, Any], notes: list[str], _choice_id: str) -> None:
+        return None
+
+    def _resolve_noncombat_effects(self, *, room: dict[str, Any], encounter: dict[str, Any], effects: list[dict[str, Any]], choice_id: str) -> list[str]:
+        notes: list[str] = []
+        rid = int(room.get("id", self.current_room_id) or self.current_room_id)
+        registry = self._noncombat_effect_registry()
+        for effect in (effects or []):
+            if not isinstance(effect, dict):
+                continue
+            etype = str(effect.get("type") or "noop").strip().lower()
+            handler = registry.get(etype, self._resolve_noncombat_effect_noop)
+            handler(effect=effect, room=room, encounter=encounter, notes=notes, _choice_id=choice_id)
         self.emit("dungeon_noncombat_choice", room_id=rid, encounter_id=str(encounter.get("id") or ""), archetype=str(encounter.get("archetype") or ""), choice=str(choice_id), notes=list(notes))
         return notes
 
@@ -3381,6 +3430,8 @@ class Game:
         if not isinstance(enc, dict):
             self.ui.log("No non-combat encounter needs attention here.")
             return CommandResult(status="info")
+        enc = normalize_noncombat_encounter(enc)
+        room["noncombat_encounter"] = enc
         if str(enc.get("status") or "active") != "active":
             self.ui.log("This encounter has already been resolved.")
             return CommandResult(status="info")
@@ -3393,7 +3444,8 @@ class Game:
         pick = self.ui.choose("Non-combat encounter", labels)
         chosen = choices[pick]
         choice_id = str(chosen.get("id") or f"choice_{pick}")
-        notes = self._resolve_noncombat_effects(room=room, encounter=enc, effects=list(chosen.get("effects") or []), choice_id=choice_id)
+        effects = [e for e in (chosen.get("effects") or []) if isinstance(e, dict)]
+        notes = self._resolve_noncombat_effects(room=room, encounter=enc, effects=effects, choice_id=choice_id)
         hist = enc.setdefault("history", [])
         if isinstance(hist, list):
             hist.append({"source": str(source), "choice": choice_id, "notes": list(notes)})
@@ -11847,7 +11899,7 @@ class Game:
             rec["trap_disabled"] = bool(trap.get("disabled", False))
 
         if isinstance(room.get("noncombat_encounter"), dict) or isinstance(rec.get("noncombat_encounter"), dict):
-            rec["noncombat_encounter"] = dict(room.get("noncombat_encounter") or rec.get("noncombat_encounter") or {})
+            rec["noncombat_encounter"] = normalize_noncombat_encounter(room.get("noncombat_encounter") or rec.get("noncombat_encounter") or {})
 
         keys = room.get("resolution_keys", rec.get("resolution_keys", []))
         if isinstance(keys, (list, tuple, set)):
@@ -11971,7 +12023,7 @@ class Game:
                 room["trap"] = dict(drec.get("trap") or {})
                 room["trap_kind"] = str(room["trap"].get("kind") or room.get("trap_kind") or "pit")
             if isinstance(drec.get("noncombat_encounter"), dict):
-                room["noncombat_encounter"] = dict(drec.get("noncombat_encounter") or {})
+                room["noncombat_encounter"] = normalize_noncombat_encounter(drec.get("noncombat_encounter") or {})
             for _k in ('event_done','feature_done','shrine_done','puzzle_done'):
                 if _k in drec:
                     room[_k] = bool(drec.get(_k))

--- a/sww/systems/dungeon_system.py
+++ b/sww/systems/dungeon_system.py
@@ -9,6 +9,7 @@ from ..commands import (
     DungeonSearchSecret,
     DungeonSearchTraps,
     DungeonInteractTrap,
+    DungeonInteractEncounter,
     DungeonSneak,
     DungeonPrepareSpells,
     DungeonCastSpell,
@@ -58,6 +59,9 @@ class DungeonSystem:
 
         if isinstance(cmd, DungeonInteractTrap):
             return g._cmd_dungeon_interact_trap()
+
+        if isinstance(cmd, DungeonInteractEncounter):
+            return g._cmd_dungeon_interact_encounter()
 
         if isinstance(cmd, DungeonSneak):
             return g._cmd_dungeon_sneak()

--- a/tests/test_dungeon_noncombat_framework.py
+++ b/tests/test_dungeon_noncombat_framework.py
@@ -1,0 +1,140 @@
+from sww.game import Game
+from sww.models import Actor, Stats
+from sww.scripted_ui import ScriptedUI
+from sww.ui_headless import HeadlessUI
+from sww.save_load import game_to_dict, apply_game_dict
+
+
+def _new_game(seed: int = 7001, scripted: bool = False) -> Game:
+    ui = ScriptedUI() if scripted else HeadlessUI()
+    g = Game(ui, dice_seed=seed)
+    g._cmd_enter_dungeon()
+    pc = Actor(name="Scout", hp=8, hp_max=8, ac_desc=8, hd=1, save=15, is_pc=True)
+    pc.stats = Stats(12, 11, 10, 10, 12, 10)
+    g.party.members = [pc]
+    g.light_on = True
+    g.torch_turns_left = 5
+    return g
+
+
+def _find_room_for_noncombat(g: Game) -> int:
+    ids = sorted(int(k) for k in (g.dungeon_instance.blueprint.data.get("rooms") or {}).keys())
+    for rid in ids:
+        room = g._ensure_room(rid)
+        if room.get("type") in {"empty", "treasure", "monster"}:
+            room["foes"] = []
+            room["trap_triggered"] = False
+            return rid
+    rid = ids[0]
+    room = g._ensure_room(rid)
+    room["foes"] = []
+    room["trap_triggered"] = False
+    return rid
+
+
+def _neighbor(g: Game, rid: int) -> int:
+    adj = g._dungeon_bp_adjacency() or {}
+    nbs = sorted(int(x) for x in (adj.get(int(rid), []) or []))
+    assert nbs
+    return nbs[0]
+
+
+def _wire_open_exit(g: Game, src: int, dest: int) -> str:
+    room = g._ensure_room(src)
+    for k, v in (room.get("exits") or {}).items():
+        if int(v) == int(dest):
+            room.setdefault("doors", {})[str(k)] = "open"
+            return str(k)
+    room.setdefault("exits", {})["A"] = int(dest)
+    room.setdefault("doors", {})["A"] = "open"
+    return "A"
+
+
+def test_noncombat_encounter_generation_and_hint_visibility():
+    g = _new_game(7002)
+    rid = _find_room_for_noncombat(g)
+    room = g._ensure_room(rid)
+    enc = g._ensure_room_noncombat_encounter(room)
+
+    assert isinstance(enc, dict)
+    assert enc.get("archetype") in {"stranded_npc", "neutral_creature", "omen_echo", "environmental_scene"}
+    assert g._dungeon_hazard_hint(room) in {"Non-combat encounter present.", "Known hazard here."}
+
+
+def test_noncombat_choice_resolution_updates_state_and_history():
+    g = _new_game(7003, scripted=True)
+    assert isinstance(g.ui, ScriptedUI)
+    rid = _find_room_for_noncombat(g)
+    room = g._ensure_room(rid)
+    room["noncombat_encounter"] = {
+        "id": f"nc:test:{rid}",
+        "archetype": "neutral_creature",
+        "status": "active",
+        "state": {"observed": False},
+        "prompt": "A neutral creature waits.",
+        "choices": [
+            {"id": "observe", "label": "Observe quietly", "effects": ["mark:observed"], "resolve": False},
+            {"id": "retreat", "label": "Back away", "effects": [], "resolve": True},
+        ],
+        "history": [],
+    }
+
+    g.ui.push(0)
+    res = g._cmd_dungeon_interact_encounter()
+
+    assert res.ok
+    enc = room.get("noncombat_encounter") or {}
+    assert enc.get("status") == "active"
+    assert (enc.get("state") or {}).get("observed") is True
+    assert len(enc.get("history") or []) == 1
+
+
+def test_noncombat_partial_state_persists_leave_return_and_save_load():
+    g = _new_game(7004, scripted=True)
+    assert isinstance(g.ui, ScriptedUI)
+    rid = _find_room_for_noncombat(g)
+    room = g._ensure_room(rid)
+    room["noncombat_encounter"] = {
+        "id": f"nc:test:{rid}",
+        "archetype": "neutral_creature",
+        "status": "active",
+        "state": {"observed": False},
+        "prompt": "A neutral creature waits.",
+        "choices": [
+            {"id": "observe", "label": "Observe quietly", "effects": ["mark:observed"], "resolve": False},
+        ],
+        "history": [],
+    }
+    g.current_room_id = rid
+    g.ui.push(0)
+    assert g._cmd_dungeon_interact_encounter().ok
+
+    nb = _neighbor(g, rid)
+    to_nb = _wire_open_exit(g, rid, nb)
+    to_rid = _wire_open_exit(g, nb, rid)
+    assert g._cmd_dungeon_move(to_nb).ok
+    assert g._cmd_dungeon_move(to_rid).ok
+
+    room_back = g._ensure_room(rid)
+    assert (room_back.get("noncombat_encounter") or {}).get("status") == "active"
+    assert ((room_back.get("noncombat_encounter") or {}).get("state") or {}).get("observed") is True
+
+    data = game_to_dict(g)
+    g2 = _new_game(7004)
+    apply_game_dict(g2, data)
+    room2 = g2._ensure_room(rid)
+    assert ((room2.get("noncombat_encounter") or {}).get("state") or {}).get("observed") is True
+    assert (room2.get("noncombat_encounter") or {}).get("status") == "active"
+
+
+def test_noncombat_generation_deterministic_with_fixed_seed():
+    def snapshot(seed: int) -> tuple[str, str]:
+        g = _new_game(seed)
+        rid = _find_room_for_noncombat(g)
+        room = g._ensure_room(rid)
+        enc = g._ensure_room_noncombat_encounter(room) or {}
+        return str(enc.get("id") or ""), str(enc.get("archetype") or "")
+
+    a = snapshot(7010)
+    b = snapshot(7010)
+    assert a == b

--- a/tests/test_dungeon_noncombat_framework.py
+++ b/tests/test_dungeon_noncombat_framework.py
@@ -3,7 +3,12 @@ from sww.models import Actor, Stats
 from sww.scripted_ui import ScriptedUI
 from sww.ui_headless import HeadlessUI
 from sww.save_load import game_to_dict, apply_game_dict
-from sww.dungeon_noncombat import build_encounter, lint_encounter_effects
+from sww.dungeon_noncombat import (
+    build_encounter,
+    lint_encounter_effects,
+    lint_authored_noncombat_content_for_ci,
+    filter_ci_fatal_lint_issues,
+)
 
 
 def _new_game(seed: int = 7001, scripted: bool = False) -> Game:
@@ -149,6 +154,7 @@ def test_unknown_effect_type_is_flagged_by_lint():
     }
     issues = lint_encounter_effects(enc)
     assert any(i.get("code") == "unknown_effect_type" for i in issues)
+    assert filter_ci_fatal_lint_issues(issues)
 
 
 def test_malformed_known_effect_is_flagged_by_lint():
@@ -159,6 +165,18 @@ def test_malformed_known_effect_is_flagged_by_lint():
     }
     issues = lint_encounter_effects(enc)
     assert any(i.get("code") == "malformed_param_type" for i in issues)
+    assert filter_ci_fatal_lint_issues(issues)
+
+
+def test_missing_required_param_is_flagged_by_lint_and_ci_fatal_filter():
+    enc = {
+        "choices": [
+            {"effects": [{"type": "heal"}]},
+        ]
+    }
+    issues = lint_encounter_effects(enc)
+    assert any(i.get("code") == "missing_required_param" for i in issues)
+    assert filter_ci_fatal_lint_issues(issues)
 
 
 def test_legacy_string_effect_lints_warning_but_remains_runtime_safe():
@@ -169,6 +187,11 @@ def test_legacy_string_effect_lints_warning_but_remains_runtime_safe():
     }
     issues = lint_encounter_effects(enc)
     assert any(i.get("code") == "legacy_effect_string" for i in issues)
+    assert filter_ci_fatal_lint_issues(issues) == []
+
+
+def test_ci_facing_builtin_content_lint_passes_clean():
+    assert lint_authored_noncombat_content_for_ci() == []
 
 
 

--- a/tests/test_dungeon_noncombat_framework.py
+++ b/tests/test_dungeon_noncombat_framework.py
@@ -127,6 +127,66 @@ def test_noncombat_partial_state_persists_leave_return_and_save_load():
     assert (room2.get("noncombat_encounter") or {}).get("status") == "active"
 
 
+
+def test_noncombat_effects_are_typed_and_registry_dispatched():
+    g = _new_game(7005, scripted=True)
+    assert isinstance(g.ui, ScriptedUI)
+    rid = _find_room_for_noncombat(g)
+    room = g._ensure_room(rid)
+    room["noncombat_encounter"] = {
+        "id": f"nc:test:{rid}",
+        "archetype": "stranded_npc",
+        "status": "active",
+        "state": {},
+        "prompt": "A stranded delver waits.",
+        "choices": [
+            {
+                "id": "aid",
+                "label": "Aid",
+                "effects": [
+                    {"type": "ration", "delta": -1},
+                    {"type": "heal", "amount": 2},
+                    {"type": "mark", "key": "aided", "value": True},
+                ],
+                "resolve": True,
+            }
+        ],
+        "history": [],
+    }
+    g.rations = 3
+    g.party.members[0].hp = 5
+    g.ui.push(0)
+    assert g._cmd_dungeon_interact_encounter().ok
+    enc = room.get("noncombat_encounter") or {}
+    assert g.rations == 2
+    assert g.party.members[0].hp >= 7
+    assert (enc.get("state") or {}).get("aided") is True
+
+
+def test_legacy_string_effects_normalize_on_load_and_resolve():
+    g = _new_game(7006, scripted=True)
+    assert isinstance(g.ui, ScriptedUI)
+    rid = _find_room_for_noncombat(g)
+    room = g._ensure_room(rid)
+    room["noncombat_encounter"] = {
+        "id": f"nc:test:{rid}",
+        "archetype": "neutral_creature",
+        "status": "active",
+        "state": {},
+        "prompt": "Legacy shape encounter.",
+        "choices": [
+            {"id": "observe", "label": "Observe", "effects": ["mark:observed"], "resolve": False},
+        ],
+        "history": [],
+    }
+    g.ui.push(0)
+    assert g._cmd_dungeon_interact_encounter().ok
+    eff = ((room.get("noncombat_encounter") or {}).get("choices") or [])[0].get("effects")
+    assert isinstance(eff[0], dict)
+    assert eff[0].get("type") == "mark"
+    assert ((room.get("noncombat_encounter") or {}).get("state") or {}).get("observed") is True
+
+
 def test_noncombat_generation_deterministic_with_fixed_seed():
     def snapshot(seed: int) -> tuple[str, str]:
         g = _new_game(seed)

--- a/tests/test_dungeon_noncombat_framework.py
+++ b/tests/test_dungeon_noncombat_framework.py
@@ -3,6 +3,7 @@ from sww.models import Actor, Stats
 from sww.scripted_ui import ScriptedUI
 from sww.ui_headless import HeadlessUI
 from sww.save_load import game_to_dict, apply_game_dict
+from sww.dungeon_noncombat import build_encounter, lint_encounter_effects
 
 
 def _new_game(seed: int = 7001, scripted: bool = False) -> Game:
@@ -126,6 +127,72 @@ def test_noncombat_partial_state_persists_leave_return_and_save_load():
     assert ((room2.get("noncombat_encounter") or {}).get("state") or {}).get("observed") is True
     assert (room2.get("noncombat_encounter") or {}).get("status") == "active"
 
+
+
+
+def test_builtin_archetype_effects_lint_clean():
+    g = _new_game(7007)
+    rid = _find_room_for_noncombat(g)
+    room = g._ensure_room(rid)
+    # Validate canonical archetype templates directly.
+    for archetype in ("stranded_npc", "neutral_creature", "omen_echo", "environmental_scene"):
+        enc = build_encounter(archetype, room=room, ctx={"room_id": rid, "depth": int(room.get("depth", 1) or 1)})
+        issues = lint_encounter_effects(enc)
+        assert issues == []
+
+
+def test_unknown_effect_type_is_flagged_by_lint():
+    enc = {
+        "choices": [
+            {"effects": [{"type": "mystery_effect", "x": 1}]},
+        ]
+    }
+    issues = lint_encounter_effects(enc)
+    assert any(i.get("code") == "unknown_effect_type" for i in issues)
+
+
+def test_malformed_known_effect_is_flagged_by_lint():
+    enc = {
+        "choices": [
+            {"effects": [{"type": "heal", "amount": "two"}]},
+        ]
+    }
+    issues = lint_encounter_effects(enc)
+    assert any(i.get("code") == "malformed_param_type" for i in issues)
+
+
+def test_legacy_string_effect_lints_warning_but_remains_runtime_safe():
+    enc = {
+        "choices": [
+            {"effects": ["mark:observed"]},
+        ]
+    }
+    issues = lint_encounter_effects(enc)
+    assert any(i.get("code") == "legacy_effect_string" for i in issues)
+
+
+
+def test_invalid_effect_slips_through_runtime_with_noop_safety_and_lint_event():
+    g = _new_game(7008, scripted=True)
+    assert isinstance(g.ui, ScriptedUI)
+    rid = _find_room_for_noncombat(g)
+    room = g._ensure_room(rid)
+    room["noncombat_encounter"] = {
+        "id": f"nc:test:{rid}",
+        "archetype": "neutral_creature",
+        "status": "active",
+        "state": {},
+        "prompt": "Invalid effect safety.",
+        "choices": [
+            {"id": "x", "label": "Do", "effects": [{"type": "unknown_x", "foo": 1}], "resolve": True},
+        ],
+        "history": [],
+    }
+    g.ui.push(0)
+    res = g._cmd_dungeon_interact_encounter()
+    assert res.ok
+    assert (room.get("noncombat_encounter") or {}).get("status") == "resolved"
+    assert any(str(getattr(evt, "name", "")) == "dungeon_noncombat_effect_lint" for evt in (getattr(g.events, "events", []) or []))
 
 
 def test_noncombat_effects_are_typed_and_registry_dispatched():

--- a/tests/test_dungeon_trap_framework.py
+++ b/tests/test_dungeon_trap_framework.py
@@ -250,14 +250,14 @@ def test_discovered_trap_choice_flow_deterministic_fixed_seed():
 
 def test_dedicated_trap_action_visibility_and_unavailability_after_resolve():
     g, _rid, room = _setup_discovered_trap_game(1300, kind="pit")
-    actions, available = g._dungeon_action_labels(room)
+    actions, available, _active_noncombat = g._dungeon_action_labels(room)
     assert available is True
     assert "Interact with discovered trap" in actions
 
     room["trap_disarmed"] = True
     room["trap"]["disarmed"] = True
     room["trap"]["disabled"] = True
-    actions2, available2 = g._dungeon_action_labels(room)
+    actions2, available2, _active_noncombat2 = g._dungeon_action_labels(room)
     assert available2 is False
     assert "Interact with discovered trap" not in actions2
 
@@ -275,7 +275,7 @@ def test_dedicated_trap_action_routes_into_existing_choice_flow():
 
 def test_dedicated_trap_action_save_load_availability_continuity():
     g, rid, room = _setup_discovered_trap_game(1302, kind="pit")
-    actions, available = g._dungeon_action_labels(room)
+    actions, available, _active_noncombat = g._dungeon_action_labels(room)
     assert available is True
     assert "Interact with discovered trap" in actions
 
@@ -284,7 +284,7 @@ def test_dedicated_trap_action_save_load_availability_continuity():
     g2 = Game(HeadlessUI(), dice_seed=1302)
     apply_game_dict(g2, data)
     room2 = g2._ensure_room(rid)
-    actions2, available2 = g2._dungeon_action_labels(room2)
+    actions2, available2, _active_noncombat2 = g2._dungeon_action_labels(room2)
     assert available2 is True
     assert "Interact with discovered trap" in actions2
 


### PR DESCRIPTION
### Motivation
- Provide a reusable layer for non-combat dungeon interactions so rooms can offer meaningful, deterministic choices beyond combat/trap resolution. 
- Keep behavior save/load safe and deterministic so encounter state persists across room leave/return and across saved games. 
- Integrate with the existing dungeon flow and reuse room/delta persistence rather than introducing a parallel subsystem. 

### Description
- Add a deterministic encounter generator and archetype templates in `sww/dungeon_noncombat.py` that implements initial archetypes: `stranded_npc`, `neutral_creature`, `omen_echo`, and `environmental_scene`. 
- Introduce a new command/action `DungeonInteractEncounter` (`sww/commands.py`) and wire it through the dungeon dispatcher in `sww/systems/dungeon_system.py` so encounters can be invoked like other dungeon actions. 
- Integrate encounter lifecycle into `sww/game.py` by adding ` _ensure_room_noncombat_encounter`, `_resolve_noncombat_encounter`, and `_resolve_noncombat_effects`, surface an explicit action in the action menu via ` _dungeon_action_labels`, and announce scene intros via ` _run_room_interaction_scene` adjustments. 
- Persist encounter state into the standard room delta (`noncombat_encounter` stored on `room["_delta"]`), restore it in `_ensure_room`, and write it in `_sync_room_to_delta` so partial resolution and history survive save/load. 
- Tests and small adjustments: add `tests/test_dungeon_noncombat_framework.py` for generation/choice/persistence, and update `tests/test_dungeon_trap_framework.py` to accommodate the expanded `_dungeon_action_labels` contract. 

### Testing
- Ran targeted unit tests for the new framework with `PYTHONPATH=. pytest -q tests/test_dungeon_noncombat_framework.py tests/test_dungeon_trap_framework.py tests/test_dungeon_room_delta_persistence.py` and observed the focused suites pass. 
- Ran the updated trap tests (`tests/test_dungeon_trap_framework.py`) alongside the new non-combat tests and they passed (`19-23 passed` across incremental runs during validation). 
- Executed the full test suite with `PYTHONPATH=. pytest -q` and observed all tests pass (`259 passed`). 
- Performed a manual/scripted flow check (enter room with non-combat encounter, make a choice, leave/return, save/load) using `ScriptedUI` and `game_to_dict`/`apply_game_dict`, which validated deterministic resolution and persistence (manual flow OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b429a714f083288856851a9c613317)